### PR TITLE
Cleanup admin routes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -176,10 +176,10 @@ func setupRoutes(g *gin.Engine, authWare *jwt.GinJWTMiddleware, db *gorm.DB, cfg
 
 	frontendProtected := g.Group("/api/v1/frontend/")
 	frontendProtected.Use(authWare.MiddlewareFunc())
-	frontendProtected.Use(middleware.RabbitMQMiddleware(mqConnectionURL))
-	frontendProtected.Use(middleware.BlockchainMiddleware(true, ethKey, ethPass))
 	frontendProtected.GET("/cost/calculate/:hash/:holdtime", CalculatePinCost)
 	frontendProtected.POST("/cost/calculate/file", CalculateFileCost)
+	frontendProtected.Use(middleware.RabbitMQMiddleware(mqConnectionURL))
+	frontendProtected.Use(middleware.BlockchainMiddleware(true, ethKey, ethPass))
 	frontendProtected.Use(middleware.DatabaseMiddleware(db))
 	frontendProtected.POST("/payment/pin/confirm/:hash", SubmitPinPaymentConfirmation)
 	frontendProtected.POST("/payment/pin/create/:hash", CreatePinPayment)

--- a/api/api.go
+++ b/api/api.go
@@ -113,12 +113,12 @@ func setupRoutes(g *gin.Engine, authWare *jwt.GinJWTMiddleware, db *gorm.DB, cfg
 	ipfsProtected.Use(authWare.MiddlewareFunc())
 	ipfsProtected.Use(middleware.APIRestrictionMiddleware(db))
 	// DATABASE-LESS routes
-	ipfsProtected.POST("/pubsub/publish/:topic", IpfsPubSubPublish)            // admin locked
-	ipfsProtected.POST("/calculate-content-hash", CalculateContentHashForFile) // admin locked
-	ipfsProtected.GET("/pins", GetLocalPins)                                   // admin locked
+	ipfsProtected.POST("/pubsub/publish/:topic", IpfsPubSubPublish)
+	ipfsProtected.POST("/calculate-content-hash", CalculateContentHashForFile)
+	ipfsProtected.GET("/pins", GetLocalPins) // admin locked
 	ipfsProtected.GET("/object-stat/:key", GetObjectStatForIpfs)
 	ipfsProtected.GET("/object/size/:key", GetFileSizeInBytesForObject)
-	ipfsProtected.GET("/check-for-pin/:hash", CheckLocalNodeForPin)
+	ipfsProtected.GET("/check-for-pin/:hash", CheckLocalNodeForPin) // admin locked
 	ipfsProtected.Use(middleware.DatabaseMiddleware(db))
 	ipfsProtected.POST("/download/:hash", DownloadContentHash)
 
@@ -136,23 +136,23 @@ func setupRoutes(g *gin.Engine, authWare *jwt.GinJWTMiddleware, db *gorm.DB, cfg
 	ipfsPrivateProtected.Use(authWare.MiddlewareFunc())
 	ipfsPrivateProtected.Use(middleware.APIRestrictionMiddleware(db))
 	ipfsPrivateProtected.Use(middleware.DatabaseMiddleware(db))
-	ipfsPrivateProtected.POST("/new/network", CreateHostedIPFSNetworkEntryInDatabase)
-	ipfsPrivateProtected.POST("/network/name", GetIPFSPrivateNetworkByName)
-	ipfsPrivateProtected.POST("/ipfs/check-for-pin/:hash", CheckLocalNodeForPinForHostedIPFSNetwork)
+	ipfsPrivateProtected.POST("/new/network", CreateHostedIPFSNetworkEntryInDatabase)                // admin locked
+	ipfsPrivateProtected.POST("/network/name", GetIPFSPrivateNetworkByName)                          // admin locked
+	ipfsPrivateProtected.POST("/ipfs/check-for-pin/:hash", CheckLocalNodeForPinForHostedIPFSNetwork) // admin locked
 	ipfsPrivateProtected.POST("/ipfs/object-stat/:key", GetObjectStatForIpfsForHostedIPFSNetwork)
 	ipfsPrivateProtected.POST("/ipfs/object/size/:key", GetFileSizeInBytesForObjectForHostedIPFSNetwork)
 	ipfsPrivateProtected.POST("/pubsub/publish/:topic", IpfsPubSubPublishToHostedIPFSNetwork)
-	ipfsPrivateProtected.POST("/pins", GetLocalPinsForHostedIPFSNetwork)
+	ipfsPrivateProtected.POST("/pins", GetLocalPinsForHostedIPFSNetwork) // admin locked
 	ipfsPrivateProtected.GET("/networks", GetAuthorizedPrivateNetworks)
 	ipfsPrivateProtected.POST("/uploads", GetUploadsByNetworkName)
-	ipfsPrivateProtected.DELETE("/pin/remove/:hash", RemovePinFromLocalHostForHostedIPFSNetwork)
+	ipfsPrivateProtected.DELETE("/pin/remove/:hash", RemovePinFromLocalHostForHostedIPFSNetwork) // admin locked
 
 	ipnsProtected := g.Group("/api/v1/ipns")
 	ipnsProtected.Use(authWare.MiddlewareFunc())
 	ipnsProtected.Use(middleware.APIRestrictionMiddleware(db))
 	ipnsProtected.Use(middleware.RabbitMQMiddleware(mqConnectionURL))
 	ipnsProtected.Use(middleware.DatabaseMiddleware(db))
-	ipnsProtected.POST("/publish/details", PublishToIPNSDetails) // admin locked
+	ipnsProtected.POST("/publish/details", PublishToIPNSDetails)
 	ipnsProtected.Use(middleware.AWSMiddleware(awsKey, awsSecret))
 	ipnsProtected.POST("/dnslink/aws/add", GenerateDNSLinkEntry) // admin locked
 
@@ -164,15 +164,15 @@ func setupRoutes(g *gin.Engine, authWare *jwt.GinJWTMiddleware, db *gorm.DB, cfg
 	clusterProtected.GET("/status-global-pin/:hash", GetGlobalStatusForClusterPin) // admin locked
 	clusterProtected.GET("/status-local", FetchLocalClusterStatus)                 // admin locked
 	clusterProtected.Use(middleware.RabbitMQMiddleware(mqConnectionURL))           // admin locked
-	clusterProtected.POST("/pin/:hash", PinHashToCluster)                          // admin locked
-	clusterProtected.DELETE("/remove-pin/:hash", RemovePinFromCluster)             // admin locked
+	clusterProtected.POST("/pin/:hash", PinHashToCluster)
+	clusterProtected.DELETE("/remove-pin/:hash", RemovePinFromCluster) // admin locked
 
 	databaseProtected := g.Group("/api/v1/database")
 	databaseProtected.Use(authWare.MiddlewareFunc())
 	databaseProtected.Use(middleware.APIRestrictionMiddleware(db))
 	databaseProtected.Use(middleware.DatabaseMiddleware(db))
-	databaseProtected.GET("/uploads", GetUploadsFromDatabase)        // admin locked
-	databaseProtected.GET("/uploads/:address", GetUploadsForAddress) // partial admin locked
+	databaseProtected.GET("/uploads", GetUploadsFromDatabase)     // admin locked
+	databaseProtected.GET("/uploads/:user", GetUploadsForAddress) // partial admin locked
 
 	frontendProtected := g.Group("/api/v1/frontend/")
 	frontendProtected.Use(authWare.MiddlewareFunc())

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -47,7 +47,7 @@ func GetUploadsForAddress(c *gin.Context) {
 	um := models.NewUploadManager(db)
 	user := GetAuthenticatedUserFromContext(c)
 	if user == AdminAddress {
-		queryUser = c.Param("user_name")
+		queryUser = c.Param("user")
 	} else {
 		queryUser = user
 	}

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -18,10 +18,6 @@ import (
 // CalculateContentHashForFile is used to calculate the content hash
 // for a particular file, without actually storing it or providing it
 func CalculateContentHashForFile(c *gin.Context) {
-	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminAddress {
-		FailNotAuthorized(c, "unauthorized access to admin route")
-	}
 	fileHandler, err := c.FormFile("file")
 	if err != nil {
 		FailOnError(c, err)
@@ -299,11 +295,6 @@ func AddFileLocally(c *gin.Context) {
 
 // IpfsPubSubPublish is used to publish a pubsub msg
 func IpfsPubSubPublish(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
-		FailNotAuthorized(c, "unauthorized access to admin route")
-		return
-	}
 	topic := c.Param("topic")
 	message, present := c.GetPostForm("message")
 	if !present {
@@ -403,6 +394,11 @@ func GetObjectStatForIpfs(c *gin.Context) {
 // CheckLocalNodeForPin is used to check whether or not
 // the local node has pinned the content
 func CheckLocalNodeForPin(c *gin.Context) {
+	ethAddress := GetAuthenticatedUserFromContext(c)
+	if ethAddress != AdminAddress {
+		FailNotAuthorized(c, "unauthorized access to admin route")
+		return
+	}
 	hash := c.Param("hash")
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
@@ -422,12 +418,6 @@ func DownloadContentHash(c *gin.Context) {
 	_, exists := c.GetPostForm("use_private_network")
 	if exists {
 		DownloadContentHashForPrivateNetwork(c)
-		return
-	}
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	// Admin locked for now
-	if ethAddress != AdminAddress {
-		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
 	var contentType string
@@ -467,7 +457,7 @@ func DownloadContentHash(c *gin.Context) {
 	var value string
 	// only process if there is actual data to process
 	// this will always be admin locked
-	if len(exHeaders) > 0 && ethAddress == AdminAddress {
+	if len(exHeaders) > 0 {
 		// the array must be of equal length, as a header has two parts
 		// the name of the header, and its value
 		// this expects the user to have properly formatted the headers

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -11,10 +11,6 @@ import (
 
 // PinHashToCluster is used to trigger a cluster pin of a particular CID
 func PinHashToCluster(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
-		FailNotAuthorized(c, "unauthorized access to cluster pin")
-	}
 	hash := c.Param("hash")
 
 	mqURL, ok := c.MustGet("mq_conn_url").(string)
@@ -66,7 +62,6 @@ func SyncClusterErrorsLocally(c *gin.Context) {
 
 // RemovePinFromCluster is used to remove a pin from the cluster global state
 // this will mean that all nodes in the cluster will no longer track the pin
-// TODO: change to use a queue
 func RemovePinFromCluster(c *gin.Context) {
 	ethAddress := GetAuthenticatedUserFromContext(c)
 	if ethAddress != AdminAddress {

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -399,6 +399,10 @@ func RemovePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 // for a private ipfs network
 func GetLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 	ethAddress := GetAuthenticatedUserFromContext(c)
+	if ethAddress != AdminAddress {
+		FailNotAuthorized(c, "unauthorized access to admin route")
+		return
+	}
 	networkName, exists := c.GetPostForm("network_name")
 	if !exists {
 		FailNoExistPostForm(c, "network_name")
@@ -480,6 +484,10 @@ func GetObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 // private ipfs network for a partilcar pin
 func CheckLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	ethAddress := GetAuthenticatedUserFromContext(c)
+	if ethAddress != AdminAddress {
+		FailNotAuthorized(c, "unauthorized access to admin route")
+		return
+	}
 	networkName, exists := c.GetPostForm("network_name")
 	if !exists {
 		FailNoExistPostForm(c, "network_name")


### PR DESCRIPTION
Made a clear distinction in the api code of which routes are admin locked that is now up to date, also removed some admin locks from non necessary calls.