### PR TITLE
Ethereum Address Change

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,6 +127,7 @@ func (api *API) setupRoutes(g *gin.Engine, authWare *jwt.GinJWTMiddleware, db *g
 	accountProtected.POST("password/change", api.changeAccountPassword)
 	accountProtected.GET("/key/ipfs/get", api.getIPFSKeyNamesForAuthUser)
 	accountProtected.POST("/key/ipfs/new", api.createIPFSKey)
+	accountProtected.POST("/ethereum/address/change", api.changeEthereumAddress)
 
 	ipfsProtected := g.Group("/api/v1/ipfs")
 	ipfsProtected.Use(authWare.MiddlewareFunc())

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -208,3 +208,30 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 		"key_ids":   keys["key_ids"],
 	})
 }
+
+// ChangeEthereumAddress is used to change a user's ethereum address
+func (api *API) changeEthereumAddress(c *gin.Context) {
+	username := GetAuthenticatedUserFromContext(c)
+	ethAddress, exists := c.GetPostForm("eth_address")
+	if !exists {
+		FailNoExistPostForm(c, "eth_address")
+		return
+	}
+	um := models.NewUserManager(api.DBM.DB)
+	_, err := um.ChangeEthereumAddress(username, ethAddress)
+	if err != nil {
+		api.Logger.WithFields(log.Fields{
+			"service": "api",
+			"user":    username,
+			"error":   err.Error(),
+		}).Info("ethereum address change failed")
+		FailOnError(c, err)
+		return
+	}
+	api.Logger.WithFields(log.Fields{
+		"service": "api",
+		"user":    username,
+	}).Info("ethereum address changed")
+
+	c.JSON(http.StatusOK, gin.H{"status": "address change successful"})
+}

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -218,8 +218,7 @@ func (api *API) changeEthereumAddress(c *gin.Context) {
 		return
 	}
 	um := models.NewUserManager(api.DBM.DB)
-	_, err := um.ChangeEthereumAddress(username, ethAddress)
-	if err != nil {
+	if _, err := um.ChangeEthereumAddress(username, ethAddress); err != nil {
 		api.Logger.WithFields(log.Fields{
 			"service": "api",
 			"user":    username,

--- a/models/user.go
+++ b/models/user.go
@@ -285,7 +285,7 @@ func (um *UserManager) FindEmailByUserName(username string) (map[string]string, 
 	return emails, nil
 }
 
-// ChangEthereumAddress is used to change a user's ethereum address
+// ChangeEthereumAddress is used to change a user's ethereum address
 func (um *UserManager) ChangeEthereumAddress(username, ethAddress string) (*User, error) {
 	u := User{}
 	if check := um.DB.Where("user_name = ?", username).First(&u); check.Error != nil {

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -1,0 +1,114 @@
+package models_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/RTradeLtd/Temporal/config"
+	"github.com/RTradeLtd/Temporal/models"
+	"github.com/RTradeLtd/Temporal/utils"
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	defaultConfigFile = "/home/solidity/config.json"
+)
+
+var (
+	travis = os.Getenv("TRAVIS") != ""
+	dbPass string
+)
+
+type args struct {
+	ethAddress        string
+	userName          string
+	email             string
+	password          string
+	enterpriseEnabled bool
+}
+
+func TestUser(t *testing.T) {
+	cfg, err := config.LoadConfig(defaultConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := openDatabaseConnection(t, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	randUtils := utils.GenerateRandomUtils()
+	username := randUtils.GenerateString(10, utils.LetterBytes)
+	ethAddress := randUtils.GenerateString(10, utils.LetterBytes)
+	email := randUtils.GenerateString(10, utils.LetterBytes)
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"NewAccount", args{ethAddress, username, email, "password123", false}},
+		{"ChangePassword", args{ethAddress, username, email, "password123", false}},
+		{"ChangeEthereumAddress", args{ethAddress, username, email, "password123", false}},
+	}
+	for _, tt := range tests {
+		switch tt.name {
+		case "NewAccount":
+			_, err = newAccount(t, db, tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+		case "ChangePassword":
+			changed, err := changePassword(t, db, tt.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !changed {
+				t.Error("password changed failed but no error was raised")
+			}
+		case "ChangeEthereumAddress":
+			_, err = changeEthereumAddress(t, db, tt.args)
+			if err != nil {
+				t.Error(err)
+			}
+		default:
+			fmt.Println("skipping... invalid test name")
+		}
+	}
+}
+
+func newAccount(t *testing.T, db *gorm.DB, args args) (*models.User, error) {
+	um := models.NewUserManager(db)
+	user, err := um.NewUserAccount(args.ethAddress, args.userName, args.password, args.email, args.enterpriseEnabled)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func changePassword(t *testing.T, db *gorm.DB, args args) (bool, error) {
+	um := models.NewUserManager(db)
+	return um.ChangePassword(args.userName, args.password, "newpassword")
+}
+
+func changeEthereumAddress(t *testing.T, db *gorm.DB, args args) (*models.User, error) {
+	um := models.NewUserManager(db)
+	user, err := um.ChangeEthereumAddress(args.userName, args.ethAddress)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+func openDatabaseConnection(t *testing.T, cfg *config.TemporalConfig) (*gorm.DB, error) {
+	if !travis {
+		dbPass = cfg.Database.Password
+	} else {
+		dbPass = ""
+	}
+	dbConnURL := fmt.Sprintf("host=127.0.0.1 port=5432 user=postgres dbname=temporal password=%s sslmode=disable", dbPass)
+
+	db, err := gorm.Open("postgres", dbConnURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db, nil
+}


### PR DESCRIPTION
# What does this PR fix
* Allows a user to change their ethereum address
* Password change bug
* Adds a missing feature for the web interface that @pseudonaut  needs
# Changes that are being made
* There is a new function  in  the user model, and api account routes that allows a user to change their ethereum address
* There was also a bug that was discovered and fixed, which prevented users from changing their password. This is because before the password is stored in the database, we hex encode it. Since making that change, i forgot to update the password change function to properly decode the hex encoded string first, before conducting a password comparison.
* I added a few tests for user account creation, password change, and ethereum address change
# Any breaking changes?
* No, however I discovered that the cgo dependencies for go-ethereum weren't in this branch. Given that robert is in middle of fixing our dependencies, I didn't commit them to github.