### PR TITLE
updated key creation queue, cleaned up logging for key creation

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -40,10 +40,11 @@ type QueueManager struct {
 // IPFSKeyCreation is a message used for processing key creation
 // only supported for the public IPFS network at the moment
 type IPFSKeyCreation struct {
-	UserName string `json:"user_name"`
-	Name     string `json:"name"`
-	Type     string `json:"type"`
-	Size     int    `json:"size"`
+	UserName    string `json:"user_name"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Size        int    `json:"size"`
+	NetworkName string `json:"network_name"`
 }
 
 // IPFSPin is a struct used when sending pin request


### PR DESCRIPTION
# What does this PR fix
* some logging cleanup to api
* prevent key creation on private networks
# Changes that are being made
* api call to create ipfs keys had it's error logging cleaned up
* key creation queue message had a "NetworkName" field added
* key creation queue checks network name, if not public log an error, and acknowledge message, continue processing new messages
# Any breaking changes?
* technically no, more so just niceties