### PR TITLE
Clean up API response

### DIFF
--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -188,7 +188,10 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		"user":    username,
 	}).Info("key creation request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{"status": "key creation sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "key creation sent to backend",
+	})
 }
 
 // GetIPFSKeyNamesForAuthUser is used to get the keys a user has setup
@@ -210,8 +213,11 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 	}).Info("key name list requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"key_names": keys["key_names"],
-		"key_ids":   keys["key_ids"],
+		"code": http.StatusOK,
+		"response": gin.H{
+			"key_names": keys["key_names"],
+			"key_ids":   keys["key_ids"],
+		},
 	})
 }
 
@@ -238,5 +244,8 @@ func (api *API) changeEthereumAddress(c *gin.Context) {
 		"user":    username,
 	}).Info("ethereum address changed")
 
-	c.JSON(http.StatusOK, gin.H{"status": "address change successful"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "address change successful",
+	})
 }

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -56,10 +56,7 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 		"user":    username,
 	}).Info("password changed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "password changed",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "password changed"})
 }
 
 // RegisterUserAccount is used to sign up with temporal
@@ -106,10 +103,7 @@ func (api *API) registerUserAccount(c *gin.Context) {
 	}).Info("user account registered")
 
 	userModel.HashedPassword = "scrubbed"
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": userModel,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": userModel})
 }
 
 // CreateIPFSKey is used to create an IPFS key
@@ -188,10 +182,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		"user":    username,
 	}).Info("key creation request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "key creation sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "key creation sent to backend"})
 }
 
 // GetIPFSKeyNamesForAuthUser is used to get the keys a user has setup
@@ -212,13 +203,7 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("key name list requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"key_names": keys["key_names"],
-			"key_ids":   keys["key_ids"],
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"key_names": keys["key_names"], "key_ids": keys["key_ids"]}})
 }
 
 // ChangeEthereumAddress is used to change a user's ethereum address
@@ -244,8 +229,5 @@ func (api *API) changeEthereumAddress(c *gin.Context) {
 		"user":    username,
 	}).Info("ethereum address changed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "address change successful",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "address change successful"})
 }

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -57,7 +57,8 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 	}).Info("password changed")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "password changed",
+		"code":     http.StatusOK,
+		"response": "password changed",
 	})
 }
 
@@ -105,8 +106,10 @@ func (api *API) registerUserAccount(c *gin.Context) {
 	}).Info("user account registered")
 
 	userModel.HashedPassword = "scrubbed"
-	c.JSON(http.StatusCreated, gin.H{"user": userModel})
-	return
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": userModel,
+	})
 }
 
 // CreateIPFSKey is used to create an IPFS key

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -33,10 +33,7 @@ func (api *API) getUploadsFromDatabase(c *gin.Context) {
 		"service": "api",
 		"user":    authenticatedUser,
 	}).Info("all uploads from database requested")
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": uploads,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": uploads})
 }
 
 // GetUploadsForAddress is used to read a list of uploads from a particular eth address
@@ -64,8 +61,5 @@ func (api *API) getUploadsForAddress(c *gin.Context) {
 		"user":    user,
 	}).Info("specific uploads from database requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": uploads,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": uploads})
 }

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -33,7 +33,10 @@ func (api *API) getUploadsFromDatabase(c *gin.Context) {
 		"service": "api",
 		"user":    authenticatedUser,
 	}).Info("all uploads from database requested")
-	c.JSON(http.StatusFound, gin.H{"uploads": uploads})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": uploads,
+	})
 }
 
 // GetUploadsForAddress is used to read a list of uploads from a particular eth address
@@ -61,5 +64,8 @@ func (api *API) getUploadsForAddress(c *gin.Context) {
 		"user":    user,
 	}).Info("specific uploads from database requested")
 
-	c.JSON(http.StatusFound, gin.H{"uploads": uploads})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": uploads,
+	})
 }

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -51,7 +51,10 @@ func (api *API) calculateIPFSFileHash(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs file hash calculation requested")
 
-	c.JSON(http.StatusOK, gin.H{"hash": hash})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": hash,
+	})
 }
 
 // CalculatePinCost is used to calculate the cost of pinning something to temporal
@@ -85,7 +88,8 @@ func (api *API) calculatePinCost(c *gin.Context) {
 	}).Info("pin cost calculation requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"total_cost_usd": totalCost,
+		"code":     http.StatusOK,
+		"response": totalCost,
 	})
 }
 
@@ -115,7 +119,8 @@ func (api *API) calculateFileCost(c *gin.Context) {
 
 	cost := utils.CalculateFileCost(holdTimeInt, file.Size)
 	c.JSON(http.StatusOK, gin.H{
-		"total_cost_usd": cost,
+		"code":     http.StatusOK,
+		"response": cost,
 	})
 }
 
@@ -218,14 +223,17 @@ func (api *API) createPinPayment(c *gin.Context) {
 	}).Info("pin payment request generated")
 
 	c.JSON(http.StatusOK, gin.H{
-		"h":                    sm.H,
-		"v":                    sm.V,
-		"r":                    sm.R,
-		"s":                    sm.S,
-		"eth_address":          sm.Address,
-		"charge_amount_in_wei": sm.ChargeAmount,
-		"payment_method":       sm.PaymentMethod,
-		"payment_number":       sm.PaymentNumber,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"h":                    sm.H,
+			"v":                    sm.V,
+			"r":                    sm.R,
+			"s":                    sm.S,
+			"eth_address":          sm.Address,
+			"charge_amount_in_wei": sm.ChargeAmount,
+			"payment_method":       sm.PaymentMethod,
+			"payment_number":       sm.PaymentNumber,
+		},
 	})
 }
 
@@ -358,14 +366,17 @@ func (api *API) createFilePayment(c *gin.Context) {
 	}).Info("file payment request generated")
 
 	c.JSON(http.StatusOK, gin.H{
-		"h":                    sm.H,
-		"v":                    sm.V,
-		"r":                    sm.R,
-		"s":                    sm.S,
-		"eth_address":          sm.Address,
-		"charge_amount_in_wei": sm.ChargeAmount,
-		"payment_method":       sm.PaymentMethod,
-		"payment_number":       sm.PaymentNumber,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"h":                    sm.H,
+			"v":                    sm.V,
+			"r":                    sm.R,
+			"s":                    sm.S,
+			"eth_address":          sm.Address,
+			"charge_amount_in_wei": sm.ChargeAmount,
+			"payment_method":       sm.PaymentMethod,
+			"payment_number":       sm.PaymentNumber,
+		},
 	})
 }
 
@@ -424,7 +435,10 @@ func (api *API) submitPinPaymentConfirmation(c *gin.Context) {
 		"payment_number": paymentNumber,
 	}).Info("pin payment confirmation being processed")
 
-	c.JSON(http.StatusOK, gin.H{"payment": pp})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": pp,
+	})
 }
 
 // SubmitPaymentToContract is a highly "insecure" way of paying for TEMPORAL and essentially involves sending us a private key
@@ -584,6 +598,7 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 	}).Info("payment submitted to contract, user clearly ignored the warnings")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": pps,
+		"code":     http.StatusOK,
+		"response": pps,
 	})
 }

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -51,10 +51,7 @@ func (api *API) calculateIPFSFileHash(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs file hash calculation requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": hash,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": hash})
 }
 
 // CalculatePinCost is used to calculate the cost of pinning something to temporal
@@ -87,10 +84,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 		"user":    username,
 	}).Info("pin cost calculation requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": totalCost,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": totalCost})
 }
 
 // CalculateFileCost is used to calculate the cost of uploading a file to our system
@@ -118,10 +112,7 @@ func (api *API) calculateFileCost(c *gin.Context) {
 	}).Info("file cost calculation requested")
 
 	cost := utils.CalculateFileCost(holdTimeInt, file.Size)
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": cost,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": cost})
 }
 
 // CreatePinPayment is used to create a signed message for a pin payment
@@ -222,19 +213,15 @@ func (api *API) createPinPayment(c *gin.Context) {
 		"payment_number": sm.PaymentNumber.String(),
 	}).Info("pin payment request generated")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"h":                    sm.H,
-			"v":                    sm.V,
-			"r":                    sm.R,
-			"s":                    sm.S,
-			"eth_address":          sm.Address,
-			"charge_amount_in_wei": sm.ChargeAmount,
-			"payment_method":       sm.PaymentMethod,
-			"payment_number":       sm.PaymentNumber,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{
+		"h":                    sm.H,
+		"v":                    sm.V,
+		"r":                    sm.R,
+		"s":                    sm.S,
+		"eth_address":          sm.Address,
+		"charge_amount_in_wei": sm.ChargeAmount,
+		"payment_method":       sm.PaymentMethod,
+		"payment_number":       sm.PaymentNumber}})
 }
 
 // CreateFilePayment is used to create a signed file payment message
@@ -365,19 +352,15 @@ func (api *API) createFilePayment(c *gin.Context) {
 		"payment_number": sm.PaymentNumber.String(),
 	}).Info("file payment request generated")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"h":                    sm.H,
-			"v":                    sm.V,
-			"r":                    sm.R,
-			"s":                    sm.S,
-			"eth_address":          sm.Address,
-			"charge_amount_in_wei": sm.ChargeAmount,
-			"payment_method":       sm.PaymentMethod,
-			"payment_number":       sm.PaymentNumber,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{
+		"h":                    sm.H,
+		"v":                    sm.V,
+		"r":                    sm.R,
+		"s":                    sm.S,
+		"eth_address":          sm.Address,
+		"charge_amount_in_wei": sm.ChargeAmount,
+		"payment_method":       sm.PaymentMethod,
+		"payment_number":       sm.PaymentNumber}})
 }
 
 // SubmitPinPaymentConfirmation is used to submit a pin payment confirmationrequest to the backend.
@@ -435,10 +418,7 @@ func (api *API) submitPinPaymentConfirmation(c *gin.Context) {
 		"payment_number": paymentNumber,
 	}).Info("pin payment confirmation being processed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": pp,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": pp})
 }
 
 // SubmitPaymentToContract is a highly "insecure" way of paying for TEMPORAL and essentially involves sending us a private key
@@ -597,8 +577,5 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 		"user":    username,
 	}).Info("payment submitted to contract, user clearly ignored the warnings")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": pps,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": pps})
 }

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -178,11 +178,14 @@ func (api *API) generateDNSLinkEntry(c *gin.Context) {
 	}).Info("dnslink entry created")
 
 	c.JSON(http.StatusOK, gin.H{
-		"record_name":  recordName,
-		"record_value": recordValue,
-		"zone_name":    awsZone,
-		"manager":      fmt.Sprintf("%+v", awsManager),
-		"region":       aws.USWest.Name,
-		"resp":         resp,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"record_name":  recordName,
+			"record_value": recordValue,
+			"zone_name":    awsZone,
+			"manager":      fmt.Sprintf("%+v", awsManager),
+			"region":       aws.USWest.Name,
+			"resp":         resp,
+		},
 	})
 }

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -108,10 +108,7 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("ipns entry creation request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "ipns entry creation sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "ipns entry creation sent to backend"})
 }
 
 // GenerateDNSLinkEntry is used to generate a DNS link entry
@@ -177,15 +174,13 @@ func (api *API) generateDNSLinkEntry(c *gin.Context) {
 		"user":    authUser,
 	}).Info("dnslink entry created")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"record_name":  recordName,
-			"record_value": recordValue,
-			"zone_name":    awsZone,
-			"manager":      fmt.Sprintf("%+v", awsManager),
-			"region":       aws.USWest.Name,
-			"resp":         resp,
-		},
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{
+		"record_name":  recordName,
+		"record_value": recordValue,
+		"zone_name":    awsZone,
+		"manager":      fmt.Sprintf("%+v", awsManager),
+		"region":       aws.USWest.Name,
+		"resp":         resp,
+	},
 	})
 }

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -109,7 +109,8 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 	}).Info("ipns entry creation request sent to backend")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "ipns entry creation sent to backend",
+		"code":     http.StatusOK,
+		"response": "ipns entry creation sent to backend",
 	})
 }
 

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -45,8 +45,9 @@ func (api *API) makeBucket(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("minio bucket created")
 
-	c.JSON(http.StatusCreated, gin.H{
-		"status": "bucket created",
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "bucket created",
 	})
 
 }

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -45,9 +45,6 @@ func (api *API) makeBucket(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("minio bucket created")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "bucket created",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "bucket created"})
 
 }

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -44,10 +44,7 @@ func (api *API) calculateContentHashForFile(c *gin.Context) {
 		"user":    username,
 	}).Info("content hash calculation for file requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": hash,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": hash})
 }
 
 // PinHashLocally is used to pin a hash to the local ipfs node
@@ -93,10 +90,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs pin request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "pin request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "pin request sent to backend"})
 }
 
 // GetFileSizeInBytesForObject is used to retrieve the size of an object in bytes
@@ -121,13 +115,7 @@ func (api *API) getFileSizeInBytesForObject(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs object file size requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"object":        key,
-			"size_in_bytes": sizeInBytes,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"object": key, "size_in_bytes": sizeInBytes}})
 
 }
 
@@ -205,10 +193,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 		"user":    username,
 	}).Info("advanced ipfs file upload requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "file upload request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "file upload request sent to backend"})
 }
 
 // AddFileLocally is used to add a file to our local ipfs node in a simple manner
@@ -310,10 +295,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 		"user":    username,
 	}).Info("simple ipfs file upload processed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": resp,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": resp})
 }
 
 // IpfsPubSubPublish is used to publish a pubsub msg
@@ -343,13 +325,7 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs pub sub message published")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"topic":   topic,
-			"message": message,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"topic": topic, "message": message}})
 }
 
 // RemovePinFromLocalHost is used to remove a pin from the  ipfs node
@@ -385,10 +361,7 @@ func (api *API) removePinFromLocalHost(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs pin removal request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "pin removal sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "pin removal sent to backend"})
 }
 
 // GetLocalPins is used to get the pins tracked by the serving ipfs node
@@ -420,10 +393,7 @@ func (api *API) getLocalPins(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("ipfs pin list requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": pinInfo,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": pinInfo})
 }
 
 // GetObjectStatForIpfs is used to get the object stats for the particular cid
@@ -448,10 +418,7 @@ func (api *API) getObjectStatForIpfs(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs object stat requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": stats,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": stats})
 }
 
 // CheckLocalNodeForPin is used to check whether or not the serving node is tacking the particular pin
@@ -480,10 +447,7 @@ func (api *API) checkLocalNodeForPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("ipfs pin check requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": present,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": present})
 }
 
 // DownloadContentHash is used to download a particular content hash from the network

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -29,12 +29,14 @@ func (api *API) calculateContentHashForFile(c *gin.Context) {
 	reader, err := fileHandler.Open()
 	if err != nil {
 		FailOnError(c, err)
+		return
 	}
 	defer reader.Close()
 	hash, err := utils.GenerateIpfsMultiHashForFile(reader)
 	if err != nil {
 		api.Logger.Error(err)
 		FailOnError(c, err)
+		return
 	}
 
 	api.Logger.WithFields(log.Fields{
@@ -42,7 +44,10 @@ func (api *API) calculateContentHashForFile(c *gin.Context) {
 		"user":    username,
 	}).Info("content hash calculation for file requested")
 
-	c.JSON(http.StatusOK, gin.H{"hash": hash})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": hash,
+	})
 }
 
 // PinHashLocally is used to pin a hash to the local ipfs node
@@ -88,7 +93,10 @@ func (api *API) pinHashLocally(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs pin request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{"status": "pin request sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "pin request sent to backend",
+	})
 }
 
 // GetFileSizeInBytesForObject is used to retrieve the size of an object in bytes
@@ -98,7 +106,7 @@ func (api *API) getFileSizeInBytesForObject(c *gin.Context) {
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
 		api.Logger.Error(err)
-		FailOnError(c, err)
+		FailOnServerError(c, err)
 		return
 	}
 	sizeInBytes, err := manager.GetObjectFileSizeInBytes(key)
@@ -114,8 +122,11 @@ func (api *API) getFileSizeInBytesForObject(c *gin.Context) {
 	}).Info("ipfs object file size requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"object":        key,
-		"size_in_bytes": sizeInBytes,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"object":        key,
+			"size_in_bytes": sizeInBytes,
+		},
 	})
 
 }
@@ -194,7 +205,10 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 		"user":    username,
 	}).Info("advanced ipfs file upload requested")
 
-	c.JSON(http.StatusOK, gin.H{"status": "file upload request sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "file upload request sent to backend",
+	})
 }
 
 // AddFileLocally is used to add a file to our local ipfs node in a simple manner
@@ -296,7 +310,10 @@ func (api *API) addFileLocally(c *gin.Context) {
 		"user":    username,
 	}).Info("simple ipfs file upload processed")
 
-	c.JSON(http.StatusOK, gin.H{"response": resp})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": resp,
+	})
 }
 
 // IpfsPubSubPublish is used to publish a pubsub msg
@@ -327,8 +344,11 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 	}).Info("ipfs pub sub message published")
 
 	c.JSON(http.StatusOK, gin.H{
-		"topic":   topic,
-		"message": message,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"topic":   topic,
+			"message": message,
+		},
 	})
 }
 
@@ -366,7 +386,8 @@ func (api *API) removePinFromLocalHost(c *gin.Context) {
 	}).Info("ipfs pin removal request sent to backend")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "pin removal sent to backend",
+		"code":     http.StatusOK,
+		"response": "pin removal sent to backend",
 	})
 }
 
@@ -399,7 +420,10 @@ func (api *API) getLocalPins(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("ipfs pin list requested")
 
-	c.JSON(http.StatusOK, gin.H{"pins": pinInfo})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": pinInfo,
+	})
 }
 
 // GetObjectStatForIpfs is used to get the object stats for the particular cid
@@ -424,7 +448,10 @@ func (api *API) getObjectStatForIpfs(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs object stat requested")
 
-	c.JSON(http.StatusOK, gin.H{"stats": stats})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": stats,
+	})
 }
 
 // CheckLocalNodeForPin is used to check whether or not the serving node is tacking the particular pin
@@ -453,7 +480,10 @@ func (api *API) checkLocalNodeForPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("ipfs pin check requested")
 
-	c.JSON(http.StatusOK, gin.H{"present": present})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": present,
+	})
 }
 
 // DownloadContentHash is used to download a particular content hash from the network

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -55,7 +55,10 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 		"user":    username,
 	}).Info("cluster pin request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{"status": "cluster pin request sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "cluster pin request sent to backend",
+	})
 }
 
 // SyncClusterErrorsLocally is used to parse through the local cluster state and sync any errors that are detected.
@@ -85,7 +88,10 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster errors parsed")
 
-	c.JSON(http.StatusOK, gin.H{"synced-cids": syncedCids})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": syncedCids,
+	})
 }
 
 // RemovePinFromCluster is used to remove a pin from the cluster global state
@@ -115,7 +121,10 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("pin removal request sent to cluster")
 
-	c.JSON(http.StatusOK, gin.H{"statsu": "pin removal request sent to cluster"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "pin removal request sent to cluster",
+	})
 }
 
 // GetLocalStatusForClusterPin is used to get teh localnode's cluster status for a particular pin
@@ -146,7 +155,10 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster status for pin requested")
 
-	c.JSON(http.StatusFound, gin.H{"status": status})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": status,
+	})
 }
 
 // GetGlobalStatusForClusterPin is used to get the global cluster status for a particular pin
@@ -177,7 +189,10 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("global cluster status for pin requested")
 
-	c.JSON(http.StatusFound, gin.H{"status": status})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": status,
+	})
 }
 
 // FetchLocalClusterStatus is used to fetch the status of the localhost's cluster state, and not the rest of the cluster
@@ -216,5 +231,11 @@ func (api *API) fetchLocalClusterStatus(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster state fetched")
 
-	c.JSON(http.StatusOK, gin.H{"cids": cids, "statuses": statuses})
+	c.JSON(http.StatusOK, gin.H{
+		"code": http.StatusOK,
+		"response": gin.H{
+			"cids":     cids,
+			"statuses": statuses,
+		},
+	})
 }

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -55,10 +55,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 		"user":    username,
 	}).Info("cluster pin request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "cluster pin request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "cluster pin request sent to backend"})
 }
 
 // SyncClusterErrorsLocally is used to parse through the local cluster state and sync any errors that are detected.
@@ -88,10 +85,7 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster errors parsed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": syncedCids,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": syncedCids})
 }
 
 // RemovePinFromCluster is used to remove a pin from the cluster global state
@@ -121,10 +115,7 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("pin removal request sent to cluster")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "pin removal request sent to cluster",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "pin removal request sent to cluster"})
 }
 
 // GetLocalStatusForClusterPin is used to get teh localnode's cluster status for a particular pin
@@ -155,10 +146,7 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster status for pin requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": status,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": status})
 }
 
 // GetGlobalStatusForClusterPin is used to get the global cluster status for a particular pin
@@ -189,10 +177,7 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("global cluster status for pin requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": status,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": status})
 }
 
 // FetchLocalClusterStatus is used to fetch the status of the localhost's cluster state, and not the rest of the cluster
@@ -231,11 +216,5 @@ func (api *API) fetchLocalClusterStatus(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("local cluster state fetched")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"cids":     cids,
-			"statuses": statuses,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"cids": cids, "statuses": statuses}})
 }

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -25,6 +25,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	networkName, exists := c.GetPostForm("network_name")
 	if !exists {
 		FailNoExistPostForm(c, "network_name")
+		return
 	}
 
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
@@ -58,14 +59,14 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	qm, err := queue.Initialize(queue.IpfsPinQueue, mqConnectionURL, true, false)
 	if err != nil {
 		api.Logger.Error(err)
-		FailOnError(c, err)
+		FailOnServerError(c, err)
 		return
 	}
 
 	err = qm.PublishMessageWithExchange(ip, queue.PinExchange)
 	if err != nil {
 		api.Logger.Error(err)
-		FailOnError(c, err)
+		FailOnServerError(c, err)
 		return
 	}
 
@@ -75,7 +76,8 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	}).Info("ipfs pin request for private network sent to backend")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "content pin request sent to backend",
+		"code":     http.StatusOK,
+		"response": "content pin request sent to backend",
 	})
 }
 
@@ -121,8 +123,11 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 	}).Info("private ipfs object file size requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"object":        key,
-		"size_in_bytes": sizeInBytes,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"object":        key,
+			"size_in_bytes": sizeInBytes,
+		},
 	})
 
 }
@@ -212,7 +217,10 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		"user":    username,
 	}).Info("advanced private ipfs file upload requested")
 
-	c.JSON(http.StatusOK, gin.H{"status": "file upload request sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "file upload request sent to backend",
+	})
 }
 
 // AddFileToHostedIPFSNetwork is used to add a file to a private IPFS network via the simple method
@@ -324,7 +332,8 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	}).Info("simple private ipfs file upload processed")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": resp,
+		"code":     http.StatusOK,
+		"response": resp,
 	})
 }
 
@@ -373,8 +382,11 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 	}).Info("private ipfs pub sub message published")
 
 	c.JSON(http.StatusOK, gin.H{
-		"topic":   topic,
-		"message": message,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"topic":   topic,
+			"message": message,
+		},
 	})
 }
 
@@ -417,7 +429,8 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 	}).Info("private ipfs pin removal request sent to backend")
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "pin removal sent to backend",
+		"code":     http.StatusOK,
+		"response": "pin removal sent to backend",
 	})
 }
 
@@ -467,7 +480,10 @@ func (api *API) getLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs pin list requested")
 
-	c.JSON(http.StatusOK, gin.H{"pins": pinInfo})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": pinInfo,
+	})
 }
 
 // GetObjectStatForIpfsForHostedIPFSNetwork is  used to get object stats from a private ipfs network
@@ -511,7 +527,10 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs object stat requested")
 
-	c.JSON(http.StatusOK, gin.H{"stats": stats})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": stats,
+	})
 }
 
 // CheckLocalNodeForPinForHostedIPFSNetwork is used to check the serving node for a pin
@@ -558,7 +577,10 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs pin check requested")
 
-	c.JSON(http.StatusOK, gin.H{"present": present})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": present,
+	})
 }
 
 // PublishDetailedIPNSToHostedIPFSNetwork is used to publish an IPNS record to a private network with fine grained control
@@ -670,7 +692,10 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipns entry creation request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{"status": "ipns entry creation request sent to backend"})
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": "ipns entry creation request sent to backend",
+	})
 }
 
 // CreateHostedIPFSNetworkEntryInDatabase is used to create an entry in the database for a private ipfs network
@@ -795,8 +820,9 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs netwokr created")
 
-	c.JSON(http.StatusCreated, gin.H{
-		"network": network,
+	c.JSON(http.StatusOK, gin.H{
+		"code":     http.StatusOK,
+		"response": network,
 	})
 
 }
@@ -824,7 +850,8 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	}).Info("private ipfs network by name requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"network": net,
+		"code":     http.StatusOK,
+		"response": net,
 	})
 }
 
@@ -847,7 +874,8 @@ func (api *API) getAuthorizedPrivateNetworks(c *gin.Context) {
 	}).Info("authorized private ipfs network listing requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"networks": networks,
+		"code":     http.StatusOK,
+		"response": networks,
 	})
 }
 
@@ -882,7 +910,8 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 	}).Info("uploads forprivate ifps network requested")
 
 	c.JSON(http.StatusOK, gin.H{
-		"uploads": uploads,
+		"code":     http.StatusOK,
+		"response": uploads,
 	})
 }
 

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -75,10 +75,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		"user":    username,
 	}).Info("ipfs pin request for private network sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "content pin request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "content pin request sent to backend"})
 }
 
 // GetFileSizeInBytesForObjectForHostedIPFSNetwork is used to get file size for an object from a private ipfs network
@@ -122,13 +119,7 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 		"user":    username,
 	}).Info("private ipfs object file size requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"object":        key,
-			"size_in_bytes": sizeInBytes,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"object": key, "size_in_bytes": sizeInBytes}})
 
 }
 
@@ -217,10 +208,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		"user":    username,
 	}).Info("advanced private ipfs file upload requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "file upload request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "file upload request sent to backend"})
 }
 
 // AddFileToHostedIPFSNetwork is used to add a file to a private IPFS network via the simple method
@@ -331,10 +319,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		"user":    username,
 	}).Info("simple private ipfs file upload processed")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": resp,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": resp})
 }
 
 // IpfsPubSubPublishToHostedIPFSNetwork is used to publish a pubsub message to a private ipfs network
@@ -381,13 +366,7 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 		"user":    username,
 	}).Info("private ipfs pub sub message published")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"topic":   topic,
-			"message": message,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"topic": topic, "message": message}})
 }
 
 // RemovePinFromLocalHostForHostedIPFSNetwork is used to remove a content hash from a private ipfs network
@@ -428,10 +407,7 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 		"user":    username,
 	}).Info("private ipfs pin removal request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "pin removal sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "pin removal sent to backend"})
 }
 
 // GetLocalPinsForHostedIPFSNetwork is used to get local pins from the serving private ipfs node
@@ -480,10 +456,7 @@ func (api *API) getLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs pin list requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": pinInfo,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": pinInfo})
 }
 
 // GetObjectStatForIpfsForHostedIPFSNetwork is  used to get object stats from a private ipfs network
@@ -527,10 +500,7 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs object stat requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": stats,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": stats})
 }
 
 // CheckLocalNodeForPinForHostedIPFSNetwork is used to check the serving node for a pin
@@ -577,10 +547,7 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs pin check requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": present,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": present})
 }
 
 // PublishDetailedIPNSToHostedIPFSNetwork is used to publish an IPNS record to a private network with fine grained control
@@ -692,10 +659,7 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipns entry creation request sent to backend")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": "ipns entry creation request sent to backend",
-	})
+	Respond(c, http.StatusOK, gin.H{"response": "ipns entry creation request sent to backend"})
 }
 
 // CreateHostedIPFSNetworkEntryInDatabase is used to create an entry in the database for a private ipfs network
@@ -818,12 +782,9 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 	api.Logger.WithFields(log.Fields{
 		"service": "api",
 		"user":    ethAddress,
-	}).Info("private ipfs netwokr created")
+	}).Info("private ipfs network created")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": network,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": network})
 
 }
 
@@ -849,10 +810,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("private ipfs network by name requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": net,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": net})
 }
 
 // GetAuthorizedPrivateNetworks is used to get the private
@@ -873,10 +831,7 @@ func (api *API) getAuthorizedPrivateNetworks(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("authorized private ipfs network listing requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": networks,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": networks})
 }
 
 // GetUploadsByNetworkName is used to getu plaods for a network by its name
@@ -909,10 +864,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 		"user":    ethAddress,
 	}).Info("uploads forprivate ifps network requested")
 
-	c.JSON(http.StatusOK, gin.H{
-		"code":     http.StatusOK,
-		"response": uploads,
-	})
+	Respond(c, http.StatusOK, gin.H{"response": uploads})
 }
 
 // DownloadContentHashForPrivateNetwork is used to download content from  a private ipfs network

--- a/api/utils.go
+++ b/api/utils.go
@@ -88,3 +88,9 @@ func GetAuthenticatedUserFromContext(c *gin.Context) string {
 	// this is their eth address
 	return claims["id"].(string)
 }
+
+// Respond is a wrapper used to handle API responses
+func Respond(c *gin.Context, status int, body gin.H) {
+	body["code"] = status
+	c.JSON(status, body)
+}

--- a/api/utils.go
+++ b/api/utils.go
@@ -23,53 +23,48 @@ func CalculateFileSize(c *gin.Context) {
 	fileHandler, err := c.FormFile("file")
 	if err != nil {
 		FailOnError(c, err)
+		return
 	}
 	size := utils.CalculateFileSizeInGigaBytes(fileHandler.Size)
 	c.JSON(http.StatusOK, gin.H{
-		"file_size_gb":    size,
-		"file_size_bytes": fileHandler.Size,
-	})
-}
-
-// FailNoExist is a failure used when somethign does not exist
-func FailNoExist(c *gin.Context, message string) {
-	c.JSON(http.StatusBadRequest, gin.H{
-		"error": message,
+		"code": http.StatusOK,
+		"response": gin.H{
+			"file_size_gb":    size,
+			"file_size_bytes": fileHandler.Size,
+		},
 	})
 }
 
 // FailNoExistPostForm is a failure used when a post form does not exist
 func FailNoExistPostForm(c *gin.Context, formName string) {
+	err := fmt.Errorf("%s post form not present", formName)
 	c.JSON(http.StatusBadRequest, gin.H{
-		"error": fmt.Sprintf("%s post form not present", formName),
+		"code":     http.StatusBadRequest,
+		"response": err.Error(),
 	})
 }
 
 // FailNotAuthorized is a failure used when a user is unauthorized for an action
 func FailNotAuthorized(c *gin.Context, message string) {
 	c.JSON(http.StatusForbidden, gin.H{
-		"error": message,
+		"code":     http.StatusForbidden,
+		"response": message,
 	})
 }
 
 // FailOnError is a failure used when an error occurs
 func FailOnError(c *gin.Context, err error) {
 	c.JSON(http.StatusBadRequest, gin.H{
-		"error": err.Error(),
+		"code":     http.StatusBadRequest,
+		"response": err.Error(),
 	})
 }
 
-// FailedToLoadDatabase is a failure used when the database cant be loaded
-func FailedToLoadDatabase(c *gin.Context) {
-	c.JSON(http.StatusBadRequest, gin.H{
-		"error": "failed to load database",
-	})
-}
-
-// FailedToLoadMiddleware is a generic failure used whenb middleware cant be loaded
-func FailedToLoadMiddleware(c *gin.Context, middlewareName string) {
-	c.JSON(http.StatusBadRequest, gin.H{
-		"error": fmt.Sprintf("failed to load %s middleware", middlewareName),
+// FailOnServerError is an error handler used when a server error occurs
+func FailOnServerError(c *gin.Context, err error) {
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"code":     http.StatusInternalServerError,
+		"response": err.Error(),
 	})
 }
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -26,21 +26,14 @@ func CalculateFileSize(c *gin.Context) {
 		return
 	}
 	size := utils.CalculateFileSizeInGigaBytes(fileHandler.Size)
-	c.JSON(http.StatusOK, gin.H{
-		"code": http.StatusOK,
-		"response": gin.H{
-			"file_size_gb":    size,
-			"file_size_bytes": fileHandler.Size,
-		},
-	})
+	Respond(c, http.StatusOK, gin.H{"response": gin.H{"file_size_gb": size, "file_size_bytes": fileHandler.Size}})
 }
 
 // FailNoExistPostForm is a failure used when a post form does not exist
 func FailNoExistPostForm(c *gin.Context, formName string) {
-	err := fmt.Errorf("%s post form not present", formName)
 	c.JSON(http.StatusBadRequest, gin.H{
 		"code":     http.StatusBadRequest,
-		"response": err.Error(),
+		"response": fmt.Sprintf("%s post form not present", formName),
 	})
 }
 


### PR DESCRIPTION
## :construction_worker: Purpose
Clean up the responses that the API gives
Addresses issues #170 

## :rocket: Changes
Responses now have the format `{"code": <status-code>, "response": <response-from-api>"}`


## :warning: Breaking Changes
No breaking changes to the code itself, but any third-party services would break (at the moment there are none so this okay)
