### PR TITLE
CLI cross-compiled binaries, CI releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /temporal
 /config.json
+/release

--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+# Cross-compile Temporal using xgo, injecting appropriate tags.
+
+RELEASE=$(git describe --tags)
+TARGETS="linux/amd64,linux/386,linux/arm,darwin/amd64,windows/amd64"
+
+mkdir -p release
+
+# dest:    output folder
+# out:     output file name
+# ldflags: set build version (git tag)
+# targets: platforms to compile for (see $TARGET)
+# deps:    for ethereum, see https://github.com/ethereum/go-ethereum/wiki/Cross-compiling-Ethereum#building-ethereum
+xgo \
+  --dest="release" \
+  --out="temporal-$(git describe --tags)" \
+  --ldflags="-X main.Version=$RELEASE" \
+  --targets="$TARGETS" \
+  --deps="https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2" \
+  ./cmd/temporal

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,20 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+before_deploy:
+  - go get -u github.com/karalabe/xgo
+  - make release-cli
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: SmSCRjP/w9DpZwXDkA17Z1h10Kd3VxcMHz5phWlzaAUO+uJkBE8Ftdvay7IJ9L4EaAMWczORz+NLNWKYerUOm8fLNwARF6yBhNA3MC/BS5qutSieg+OCbxnq+5R45kFjNlz/KHprwB5MTCFY7g6DxDM9DO5bTw82rZCThy9yPKXWbx9EOLuyiuTA7ss01JSJGO/e+3GUfjrN493e9mrHZ+Wd5SJpjag1HUOTWVEAKPl6KT5GTVs4g/ygFhvtqlq7ya7aBrvBb90VxGaslSgH5bqbT+7T97++Me8HErYJ4Q5alfIdaHYE9ITXiMv4tJHB1x8JhTd5Rm/ogrwVFpMtstFiIJYdoeTZr4FzIK+feQ8gH3S/HwzBepJjXdxMm9IoUeDs/kWtrMym0epZmdgb7E8rGU01rB1EnLDC/+KW7wyRK1iD479An6/B9E7PLgPAoxNQ2GCailwQaVhLk+s9SwyFjOv8OiZjnIl4NRi8FhLdtm8p0IAgUnuILsuxAf060ymaCfwD4+mwm7w2RSalpG232UK8U2tMKtfQ+DoAxew1vHUDCEUsyqhqL0KjuWxILMs7lzR5BPa3SsiXQNcTcxt160VdE2Wjz0HaQ6ExQUaOKMEKURZzZb7CUnvWMKVDka1Gh9yAamKWR2Hh8XRhWkYbAh6UNQuDX41nKrT/kmA=
+  file_glob: true
+  file: release/temporal-*
+  on:
+    tags: true
+    repo: RTradeLtd/Temporal
+
 notifications: 
   email: false 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 GOFILES=`go list ./... | grep -v /vendor/`
-TEMPORALVERSION = `git describe --tags`
+TEMPORALVERSION=`git describe --tags`
 IPFSVERSION=v0.4.17
 
 all: check cli
-
-# Installs Temporal to GOBIN
-install: cli
-	@echo "=================== installing Temporal CLI ==================="
-	go install -ldflags "-X main.Version=$(TEMPORALVERSION)" cmd/temporal
-	@echo "===================          done           ==================="
 
 # List all commands
 .PHONY: ls
 ls:
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+
+# Installs Temporal to GOBIN
+.PHONY: install
+install: cli
+	@echo "=================== installing Temporal CLI ==================="
+	go install -ldflags "-X main.Version=$(TEMPORALVERSION)" cmd/temporal
+	@echo "===================          done           ==================="
 
 # Run simple checks
 .PHONY: check
@@ -85,4 +86,11 @@ vendor:
 	go get -u github.com/ethereum/go-ethereum
 	cp -r $(GOPATH)/src/github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1 \
   	./vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/
+	@echo "===================          done           ==================="
+
+# Build release
+.PHONY: release-cli
+release-cli:
+	@echo "===================   cross-compiling CLI   ==================="
+	@bash .scripts/release.sh
 	@echo "===================          done           ==================="


### PR DESCRIPTION
## :construction_worker: Purpose

Add cross-platform builds to Travis for tagged builds. Unfortunately `go-ethereum` has some cgo stuff that made this not very straight forward, so opted to use `xgo` instead of `gox`, which makes this build very slow.

## :rocket: Changes

- Added new script for cross-compiling the CLI
- Added travis deploy step

## :warning: Breaking Changes

none