### PR TITLE
IPFS Key Name Change and API Call Check

### DIFF
--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -152,6 +152,10 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	for _, v := range keys["key_names"] {
 		if v == keyNamePrefixed {
 			err = fmt.Errorf("key with name already exists")
+			api.Logger.WithFields(log.Fields{
+				"service": "api",
+				"error":   err.Error(),
+			}).Error("user attempting to create duplicate key")
 			FailOnError(c, err)
 			return
 		}

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -138,7 +138,24 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		FailNoExistPostForm(c, "key_name")
 		return
 	}
-
+	um := models.NewUserManager(api.DBM.DB)
+	keys, err := um.GetKeysForUser(username)
+	if err != nil {
+		api.Logger.WithFields(log.Fields{
+			"service": "api",
+			"error":   err.Error(),
+		}).Error("failed to retrieve keys for user")
+		FailOnError(c, err)
+		return
+	}
+	keyNamePrefixed := fmt.Sprintf("%s-%s", username, keyName)
+	for _, v := range keys["key_names"] {
+		if v == keyNamePrefixed {
+			err = fmt.Errorf("key with name already exists")
+			FailOnError(c, err)
+			return
+		}
+	}
 	bitsInt, err := strconv.Atoi(keyBits)
 	if err != nil {
 		FailOnError(c, err)

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -90,7 +90,8 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 			d.Ack(false)
 			continue
 		}
-		pk, err := manager.KeystoreManager.CreateAndSaveKey(key.Name, keyTypeInt, bitsInt)
+		keyName := fmt.Sprintf("%s-%s", key.UserName, key.Name)
+		pk, err := manager.KeystoreManager.CreateAndSaveKey(keyName, keyTypeInt, bitsInt)
 		if err != nil {
 			qm.Logger.WithFields(log.Fields{
 				"service": qm.QueueName,
@@ -111,7 +112,7 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 			d.Ack(false)
 			continue
 		}
-		err = userManager.AddIPFSKeyForUser(key.UserName, key.Name, id.Pretty())
+		err = userManager.AddIPFSKeyForUser(key.UserName, keyName, id.Pretty())
 		if err != nil {
 			qm.Logger.WithFields(log.Fields{
 				"service": qm.QueueName,


### PR DESCRIPTION
## :construction_worker: Purpose
Refines IPFS key creation api call
Updates IPFS key names

## :rocket: Changes
Check to see whether or not a user has created a key with the same name before during the API call
Key name has been changed to avoid namespace confliction, they are all prepended with the username
 

## :warning: Breaking Changes
None, just a change to new IPFS key names

