### PR TITLE
API Error Logging Cleanup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,12 +34,13 @@ type API struct {
 	TConfig *config.TemporalConfig
 	DBM     *database.DatabaseManager
 	Logger  *log.Logger
+	Service string
 }
 
 // Initialize is used ot initialize our API service
 func Initialize(cfg *config.TemporalConfig, logMode bool) (*API, error) {
 	// initialize an empty api struct
-	api := API{}
+	api := API{Service: "api"}
 	// setup logging
 	err := api.setupLogging()
 	if err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -37,4 +37,38 @@ const (
 	MinioPutError = "failed to store object in minio"
 	// MinioConnectionError is an error used when connecting to minio
 	MinioConnectionError = "failed to connect to minio"
+	// MinioBucketCreationError is an error used when creating a minio bucket
+	MinioBucketCreationError = "failed to create minio bucket"
+	// IPFSMultiHashGenerationError is an error used when calculating an ipfs multihash
+	IPFSMultiHashGenerationError = "failed to generate ipfs multihash"
+	// IPFSClusterStatusError is a error used when getting the status of ipfs cluster
+	IPFSClusterStatusError = "failed to get ipfs cluster status"
+	// IPFSClusterConnectionError is an error used when connecting to ipfs cluster
+	IPFSClusterConnectionError = "failed to connect to IPFS cluster"
+	// IPFSClusterPinRemovalError is an error used when failing to remove a pin from the cluster
+	IPFSClusterPinRemovalError = "failed to remove pin from cluster"
+	// DNSLinkManagerError is an error used when creating a dns link manager
+	DNSLinkManagerError = "failed to create dnslink manager"
+	// DNSLinkEntryError is an error used when creating dns link entries
+	DNSLinkEntryError = "failed to create dns link entry"
+	// PaymentCreationError is an error used when creating payments
+	PaymentCreationError = "failed to create payment"
+	// PaymentMessageSignError is an error used when signing payment messages
+	PaymentMessageSignError = "failed to sign payment message"
+	// PaymentSignerGenerationError is an error used when generating the payment signer
+	PaymentSignerGenerationError = "failed to generate payment signer"
+	// EthAddressSearchError is an error used when searching for an eth address
+	EthAddressSearchError = "failed to search for eth address"
+	// PinCostCalculationError is an error message used when calculating pin costs
+	PinCostCalculationError = "failed to calculate pin cost"
+	// PaymentSearchError is an error used when searching for payment
+	PaymentSearchError = "failed to search for payment"
+	// EthAddressChangeError is an error used when changing your eth address
+	EthAddressChangeError = "failed to changing eth address"
+	// DuplicateKeyCreationError is an error used when creating a key of the same name
+	DuplicateKeyCreationError = "key name already exists"
+	// UserAccountCreationError is an error used when creating a user account
+	UserAccountCreationError = "failed to create user account"
+	// PasswordChangeError is an error used when changing your password
+	PasswordChangeError = "failed to change password"
 )

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,40 @@
+package api
+
+const (
+	// IPFSConnectionError is an error used for ipfs connection failures
+	IPFSConnectionError = "failed to connect to ipfs"
+	// PrivateNetworkAccessError is used for invalid access to private networks
+	PrivateNetworkAccessError = "invalid access to private netowrk"
+	// APIURLCheckError is an error ussed when failing to retrieve an api url
+	APIURLCheckError = "failed to get api url"
+	// IPFSCatError is an error used when failing to can an ipfs file
+	IPFSCatError = "failed to execute ipfs cat"
+	// IPFSObjectStatError is an error used when failure to execute object stat occurs
+	IPFSObjectStatError = "failed to execute ipfs object stat"
+	// IPFSPubSubPublishError is an error message used whe nfailing to publish pubsub msgs
+	IPFSPubSubPublishError = "failed to publish pubsub message"
+	// UploadSearchError is a error used when searching for uploads fails
+	UploadSearchError = "failed to search for uploads in database"
+	// NetworkSearchError is an error used when searching for networks fail
+	NetworkSearchError = "faild to search for networks"
+	// NetworkCreationError is an error used when creating networks in database fail
+	NetworkCreationError = "failed to create network"
+	// QueueInitializationError is an error used when failing to connect to the queue
+	QueueInitializationError = "failed to initialize queue"
+	// QueuePublishError is a message used when failing to publish to queue
+	QueuePublishError = "failed to publish message to queue"
+	// KeySearchError is an error used when failing to search for a key
+	KeySearchError = "failed to search for key"
+	// KeyUseError is an error used when attempting to use a key the user down ot own
+	KeyUseError = "user does not own key"
+	// IPFSPinParseError is an error used when failure to parse ipfs pins occurs
+	IPFSPinParseError = "failed to parse ipfs pins"
+	// IPFSAddError is an error used when failing to add a file to ipfs
+	IPFSAddError = "failed to add file to ipfs"
+	// FileOpenError is an error used when failing to open a file
+	FileOpenError = "failed to open file"
+	// MinioPutError is an error used when storing a file in minio
+	MinioPutError = "failed to store object in minio"
+	// MinioConnectionError is an error used when connecting to minio
+	MinioConnectionError = "failed to connect to minio"
+)

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -169,8 +169,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		return
 	}
 
-	err = qm.PublishMessageWithExchange(key, queue.IpfsKeyExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(key, queue.IpfsKeyExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/RTradeLtd/Temporal/models"
@@ -15,8 +14,6 @@ var dev = false
 func (api *API) getUploadsFromDatabase(c *gin.Context) {
 	authenticatedUser := GetAuthenticatedUserFromContext(c)
 	if authenticatedUser != AdminAddress {
-		msg := fmt.Sprintf("user %s attempted unauthorized access to get uploads from database admin route", authenticatedUser)
-		api.Logger.Warn(msg)
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -24,8 +21,7 @@ func (api *API) getUploadsFromDatabase(c *gin.Context) {
 	// fetch the uplaods
 	uploads, err := um.GetUploads()
 	if err != nil {
-		msg := fmt.Sprintf("get uploads from database failed due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, UploadSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -50,8 +46,7 @@ func (api *API) getUploadsForAddress(c *gin.Context) {
 	// fetch all uploads for that address
 	uploads, err := um.GetUploadsForUser(queryUser)
 	if err != nil {
-		msg := fmt.Sprintf("get uploads from database for user %s failed due to the following error: %s", queryUser, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, UploadSearchError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -191,8 +191,7 @@ func (api *API) createPinPayment(c *gin.Context) {
 		return
 	}
 
-	_, err = ppm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, contentHash, username, "pin", "public", holdTimeInt)
-	if err != nil {
+	if _, err = ppm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, contentHash, username, "pin", "public", holdTimeInt); err != nil {
 		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
@@ -287,8 +286,7 @@ func (api *API) createFilePayment(c *gin.Context) {
 	randString := randUtils.GenerateString(32, utils.LetterBytes)
 	objectName := fmt.Sprintf("%s%s", username, randString)
 	fmt.Println("storing file in minio")
-	_, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{})
-	if err != nil {
+	if _, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{}); err != nil {
 		api.LogError(err, MinioPutError)
 		FailOnError(c, err)
 		return
@@ -326,8 +324,7 @@ func (api *API) createFilePayment(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	_, err = pm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, objectName, username, "file", networkName, holdTimeInMonthsInt)
-	if err != nil {
+	if _, err = pm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, objectName, username, "file", networkName, holdTimeInMonthsInt); err != nil {
 		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
@@ -393,8 +390,7 @@ func (api *API) submitPinPaymentConfirmation(c *gin.Context) {
 		return
 	}
 	fmt.Println("publishing message")
-	err = qm.PublishMessage(ppc)
-	if err != nil {
+	if err = qm.PublishMessage(ppc); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -553,8 +549,7 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 		Sig:          sm.Sig,
 	}
 
-	_, err = ppm.NewPayment(uint8(methodUint), number, costBig, ethAddress, contentHash, username, "pin", "public", holdTimeInt)
-	if err != nil {
+	if _, err = ppm.NewPayment(uint8(methodUint), number, costBig, ethAddress, contentHash, username, "pin", "public", holdTimeInt); err != nil {
 		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
@@ -566,8 +561,7 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 		return
 	}
 
-	err = qm.PublishMessage(pps)
-	if err != nil {
+	if err = qm.PublishMessage(pps); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -33,15 +33,13 @@ func (api *API) calculateIPFSFileHash(c *gin.Context) {
 	}
 	fh, err := file.Open()
 	if err != nil {
-		msg := fmt.Sprintf("failed to open file due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, FileOpenError)
 		FailOnError(c, err)
 		return
 	}
 	hash, err := utils.GenerateIpfsMultiHashForFile(fh)
 	if err != nil {
-		msg := fmt.Sprintf("failed to calculate ipfs hash for file due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, IPFSMultiHashGenerationError)
 		FailOnError(c, err)
 		return
 	}
@@ -61,8 +59,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 	holdTime := c.Param("holdtime")
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
-		msg := fmt.Sprintf("failed to initialize connection to IPFS due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
@@ -73,8 +70,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 	}
 	totalCost, err := utils.CalculatePinCost(hash, holdTimeInt, manager.Shell)
 	if err != nil {
-		msg := fmt.Sprintf("failed to calculate pin costfor hash %s  due to the followign error: %s", hash, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PinCostCalculationError)
 		FailOnError(c, err)
 		return
 	}
@@ -146,15 +142,13 @@ func (api *API) createPinPayment(c *gin.Context) {
 
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
-		msg := fmt.Sprintf("failed to initialize connection to IPFS due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	totalCost, err := utils.CalculatePinCost(contentHash, holdTimeInt, manager.Shell)
 	if err != nil {
-		msg := fmt.Sprintf("failed to calculate pin cost for hash %s due to the following error: %s", contentHash, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PinCostCalculationError)
 		FailOnError(c, err)
 		return
 	}
@@ -163,15 +157,14 @@ func (api *API) createPinPayment(c *gin.Context) {
 	keyPass := api.TConfig.Ethereum.Account.KeyPass
 	ps, err := signer.GeneratePaymentSigner(keyFile, keyPass)
 	if err != nil {
-		msg := fmt.Sprintf("failed to generate payment signer due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentSignerGenerationError)
 		FailOnError(c, err)
 		return
 	}
 	um := models.NewUserManager(api.DBM.DB)
 	ethAddress, err := um.FindEthAddressByUserName(username)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, EthAddressSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -179,7 +172,7 @@ func (api *API) createPinPayment(c *gin.Context) {
 	var num *big.Int
 	num, err = ppm.RetrieveLatestPaymentNumberForUser(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.Logger.Error(err)
+		api.LogError(err, PaymentSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -193,16 +186,14 @@ func (api *API) createPinPayment(c *gin.Context) {
 
 	sm, err := ps.GenerateSignedPaymentMessagePrefixed(addressTyped, uint8(methodUint), num, costBig)
 	if err != nil {
-		msg := fmt.Sprintf("failed to generate signed payment message for user %s due to the following error: %s", username, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentMessageSignError)
 		FailOnError(c, err)
 		return
 	}
 
 	_, err = ppm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, contentHash, username, "pin", "public", holdTimeInt)
 	if err != nil {
-		msg := fmt.Sprintf("failed to create payment record in database for user %s due to the following error: %s", username, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
 	}
@@ -264,15 +255,13 @@ func (api *API) createFilePayment(c *gin.Context) {
 	keyPass := api.TConfig.Ethereum.Account.KeyPass
 	ps, err := signer.GeneratePaymentSigner(keyFile, keyPass)
 	if err != nil {
-		msg := fmt.Sprintf("failed to generate payment signer due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentSignerGenerationError)
 		FailOnError(c, err)
 		return
 	}
 	miniManager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, false)
 	if err != nil {
-		msg := fmt.Sprintf("failed to initialize connection to minio due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, MinioConnectionError)
 		FailOnError(c, err)
 		return
 	}
@@ -280,6 +269,7 @@ func (api *API) createFilePayment(c *gin.Context) {
 	fmt.Println("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
+		api.LogError(err, FileOpenError)
 		FailOnError(c, err)
 		return
 	}
@@ -299,8 +289,7 @@ func (api *API) createFilePayment(c *gin.Context) {
 	fmt.Println("storing file in minio")
 	_, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{})
 	if err != nil {
-		msg := fmt.Sprintf("failed to store file in minio due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, MinioPutError)
 		FailOnError(c, err)
 		return
 	}
@@ -310,14 +299,14 @@ func (api *API) createFilePayment(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	ethAddress, err := um.FindEthAddressByUserName(username)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, EthAddressSearchError)
 		FailOnError(c, err)
 		return
 	}
 	var num *big.Int
 	num, err = pm.RetrieveLatestPaymentNumberForUser(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.Logger.Error(err)
+		api.LogError(err, PaymentSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -333,15 +322,13 @@ func (api *API) createFilePayment(c *gin.Context) {
 	addressTyped := common.HexToAddress(ethAddress)
 	sm, err := ps.GenerateSignedPaymentMessagePrefixed(addressTyped, uint8(methodUint), num, costBig)
 	if err != nil {
-		msg := fmt.Sprintf("failed to generate signed message for file upload for user %s due to the following error: %s", username, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentMessageSignError)
 		FailOnError(c, err)
 		return
 	}
 	_, err = pm.NewPayment(uint8(methodUint), sm.PaymentNumber, sm.ChargeAmount, ethAddress, objectName, username, "file", networkName, holdTimeInMonthsInt)
 	if err != nil {
-		msg := fmt.Sprintf("failed to store payment information in database for user %s due to the following error: %s", username, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
 	}
@@ -381,11 +368,13 @@ func (api *API) submitPinPaymentConfirmation(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	ethAddress, err := um.FindEthAddressByUserName(username)
 	if err != nil {
+		api.LogError(err, EthAddressSearchError)
 		FailOnError(c, err)
 		return
 	}
 	pp, err := ppm.FindPaymentByNumberAndAddress(paymentNumber, ethAddress)
 	if err != nil {
+		api.LogError(err, PaymentSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -399,16 +388,14 @@ func (api *API) submitPinPaymentConfirmation(c *gin.Context) {
 	}
 	qm, err := queue.Initialize(queue.PinPaymentConfirmationQueue, mqURL, true, false)
 	if err != nil {
-		msg := fmt.Sprintf("failed to initialize connection to queue due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 	fmt.Println("publishing message")
 	err = qm.PublishMessage(ppc)
 	if err != nil {
-		msg := fmt.Sprintf("failed to publish msg to queue %s due to the following error: %s", queue.PinPaymentConfirmationQueue, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -452,6 +439,7 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 	}
 	keyFileHandler, err := keyFile.Open()
 	if err != nil {
+		api.LogError(err, FileOpenError)
 		FailOnError(c, err)
 		return
 	}
@@ -482,11 +470,13 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	totalCost, err := utils.CalculatePinCost(contentHash, holdTimeInt, manager.Shell)
 	if err != nil {
+		api.LogError(err, PinCostCalculationError)
 		FailOnError(c, err)
 		return
 	}
@@ -498,12 +488,14 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	ethAddress, err := um.FindEthAddressByUserName(username)
 	if err != nil {
+		api.LogError(err, EthAddressSearchError)
 		FailOnError(c, err)
 		return
 	}
 	var number *big.Int
 	num, err := ppm.RetrieveLatestPaymentNumberForUser(username)
 	if err != nil {
+		api.LogError(err, PaymentSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -517,26 +509,31 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 		api.TConfig.Ethereum.Account.KeyFile,
 		api.TConfig.Ethereum.Account.KeyPass)
 	if err != nil {
+		api.LogError(err, PaymentSignerGenerationError)
 		FailOnError(c, err)
 		return
 	}
 	sm, err := ps.GenerateSignedPaymentMessagePrefixed(addressTyped, uint8(methodUint), number, costBig)
 	if err != nil {
+		api.LogError(err, PaymentMessageSignError)
 		FailOnError(c, err)
 		return
 	}
 	jsonKeyBytes, err := ioutil.ReadAll(keyFileHandler)
 	if err != nil {
+		// so in frequently used not logging
 		FailOnError(c, err)
 		return
 	}
 	pk, err := keystore.DecryptKey(jsonKeyBytes, ethPass)
 	if err != nil {
+		// so in frequently used not logging
 		FailOnError(c, err)
 		return
 	}
 	marshaledKey, err := pk.MarshalJSON()
 	if err != nil {
+		// so in frequently used not logging
 		FailOnError(c, err)
 		return
 	}
@@ -558,17 +555,20 @@ func (api *API) submitPaymentToContract(c *gin.Context) {
 
 	_, err = ppm.NewPayment(uint8(methodUint), number, costBig, ethAddress, contentHash, username, "pin", "public", holdTimeInt)
 	if err != nil {
+		api.LogError(err, PaymentCreationError)
 		FailOnError(c, err)
 		return
 	}
 	qm, err := queue.Initialize(queue.PinPaymentSubmissionQueue, mqURL, true, false)
 	if err != nil {
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 
 	err = qm.PublishMessage(pps)
 	if err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -51,14 +51,15 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 
 	ownsKey, err := um.CheckIfKeyOwnedByUser(ethAddress, key)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, KeySearchError)
 		FailOnError(c, err)
 		return
 	}
 
 	if !ownsKey {
-		api.Logger.Warnf("user %s attempted to generate IPFS entry with unowned key", ethAddress)
-		FailOnError(c, errors.New("attempting to generate IPNS entry with unowned key"))
+		err = fmt.Errorf("user %s attempted to generate IPFS entry with unowned key", ethAddress)
+		api.LogError(err, KeyUseError)
+		FailOnError(c, err)
 		return
 	}
 	resolve, err := strconv.ParseBool(resolveString)
@@ -91,14 +92,14 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 
 	qm, err := queue.Initialize(queue.IpnsEntryQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 	//TODO move to fanout exchange
 	err = qm.PublishMessage(ie)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -151,20 +152,21 @@ func (api *API) generateDNSLinkEntry(c *gin.Context) {
 	case "us-west-1":
 		region = aws.USWest
 	default:
+		// user error, do not log
 		FailOnError(c, errors.New("invalid region_name"))
 		return
 	}
 
 	awsManager, err := dlink.GenerateAwsLinkManager("get", aKey, aSecret, awsZone, region)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, DNSLinkManagerError)
 		FailOnError(c, err)
 		return
 	}
 
 	resp, err := awsManager.AddDNSLinkEntry(recordName, recordValue)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, DNSLinkEntryError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -96,9 +96,9 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	//TODO move to fanout exchange
-	err = qm.PublishMessage(ie)
-	if err != nil {
+	// in order to avoid generating too much IPFS dht traffic, we publish round-robin style
+	// as we announce the records to the swarm, we will eventually achieve consistency across nodes automatically
+	if err = qm.PublishMessage(ie); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -33,8 +33,7 @@ func (api *API) makeBucket(c *gin.Context) {
 
 	args := make(map[string]string)
 	args["name"] = bucketName
-	err = manager.MakeBucket(args)
-	if err != nil {
+	if err = manager.MakeBucket(args); err != nil {
 		api.LogError(err, MinioBucketCreationError)
 		FailOnError(c, err)
 		return

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -26,7 +26,7 @@ func (api *API) makeBucket(c *gin.Context) {
 	endpoint := fmt.Sprintf("%s:%s", api.TConfig.MINIO.Connection.IP, api.TConfig.MINIO.Connection.Port)
 	manager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, true)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, MinioConnectionError)
 		FailOnError(c, err)
 		return
 	}
@@ -35,7 +35,7 @@ func (api *API) makeBucket(c *gin.Context) {
 	args["name"] = bucketName
 	err = manager.MakeBucket(args)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, MinioBucketCreationError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -79,8 +79,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 		return
 	}
 
-	err = qm.PublishMessageWithExchange(ip, queue.PinExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -161,8 +160,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	randString := randUtils.GenerateString(32, utils.LetterBytes)
 	objectName := fmt.Sprintf("%s%s", username, randString)
 	fmt.Println("storing file in minio")
-	_, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{})
-	if err != nil {
+	if _, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{}); err != nil {
 		api.LogError(err, MinioPutError)
 		FailOnError(c, err)
 		return
@@ -182,8 +180,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 		return
 	}
 
-	err = qm.PublishMessage(ifp)
-	if err != nil {
+	if err = qm.PublishMessage(ifp); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -262,11 +259,8 @@ func (api *API) addFileLocally(c *gin.Context) {
 		return
 	}
 
-	// Consider whether or not we should trigger a cluster pin here
-
 	// publish the database file add message
-	err = qm.PublishMessage(dfa)
-	if err != nil {
+	if err = qm.PublishMessage(dfa); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -285,8 +279,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	err = qm.PublishMessageWithExchange(pin, queue.PinExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(pin, queue.PinExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -315,8 +308,7 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	err = manager.PublishPubSubMessage(topic, message)
-	if err != nil {
+	if err = manager.PublishPubSubMessage(topic, message); err != nil {
 		api.LogError(err, IPFSPubSubPublishError)
 		FailOnError(c, err)
 		return
@@ -351,8 +343,7 @@ func (api *API) removePinFromLocalHost(c *gin.Context) {
 		NetworkName: "public",
 		UserName:    username,
 	}
-	err = qm.PublishMessageWithExchange(rm, queue.PinRemovalExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(rm, queue.PinRemovalExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -31,7 +31,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 
 	qm, err := queue.Initialize(queue.IpfsClusterPinQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
@@ -45,7 +45,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 
 	err = qm.PublishMessage(ipfsClusterPin)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -68,14 +68,14 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 	// initialize a conection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	// parse the local cluster status, and sync any errors, retunring the cids that were in an error state
 	syncedCids, err := manager.ParseLocalStatusAllAndSync()
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterStatusError)
 		FailOnError(c, err)
 		return
 	}
@@ -99,13 +99,13 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 	hash := c.Param("hash")
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	err = manager.RemovePinFromCluster(hash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterPinRemovalError)
 		FailOnError(c, err)
 		return
 	}
@@ -129,14 +129,14 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 	// initialize a connection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	// get the cluster status for the cid only asking the local cluster node
 	status, err := manager.GetStatusForCidLocally(hash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterStatusError)
 		FailOnError(c, err)
 		return
 	}
@@ -160,14 +160,14 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 	// initialize a connection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	// get teh cluster wide status for this particular pin
 	status, err := manager.GetStatusForCidGlobally(hash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterStatusError)
 		FailOnError(c, err)
 		return
 	}
@@ -194,14 +194,14 @@ func (api *API) fetchLocalClusterStatus(c *gin.Context) {
 	// initialize a connection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	// fetch a map of all the statuses
 	maps, err := manager.FetchLocalStatus()
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSClusterStatusError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -43,8 +43,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 		HoldTimeInMonths: holdTimeInt,
 	}
 
-	err = qm.PublishMessage(ipfsClusterPin)
-	if err != nil {
+	if err = qm.PublishMessage(ipfsClusterPin); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -90,6 +89,7 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 
 // RemovePinFromCluster is used to remove a pin from the cluster global state
 // this will mean that all nodes in the cluster will no longer track the pin
+// TODO: use a queue
 func (api *API) removePinFromCluster(c *gin.Context) {
 	ethAddress := GetAuthenticatedUserFromContext(c)
 	if ethAddress != AdminAddress {
@@ -103,8 +103,7 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	err = manager.RemovePinFromCluster(hash)
-	if err != nil {
+	if err = manager.RemovePinFromCluster(hash); err != nil {
 		api.LogError(err, IPFSClusterPinRemovalError)
 		FailOnError(c, err)
 		return

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -63,8 +63,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 
-	err = qm.PublishMessageWithExchange(ip, queue.PinExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnServerError(c, err)
 		return
@@ -86,8 +85,7 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 		FailNoExistPostForm(c, "network_name")
 		return
 	}
-	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -134,8 +132,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		return
 	}
 
-	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -177,8 +174,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	randString := randUtils.GenerateString(32, utils.LetterBytes)
 	objectName := fmt.Sprintf("%s%s", username, randString)
 	fmt.Println("storing file in minio")
-	_, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{})
-	if err != nil {
+	if _, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{}); err != nil {
 		api.LogError(err, MinioPutError)
 		FailOnError(c, err)
 		return
@@ -222,8 +218,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 
-	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -331,8 +326,7 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 		FailNoExistPostForm(c, "network_name")
 		return
 	}
-	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -357,8 +351,7 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	err = manager.PublishPubSubMessage(topic, message)
-	if err != nil {
+	if err = manager.PublishPubSubMessage(topic, message); err != nil {
 		api.LogError(err, IPFSPubSubPublishError)
 		FailOnError(c, err)
 		return
@@ -381,8 +374,7 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 		FailNoExistPostForm(c, "network_name")
 		return
 	}
-	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -399,8 +391,7 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-	err = qm.PublishMessageWithExchange(rm, queue.PinRemovalExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(rm, queue.PinRemovalExchange); err != nil {
 		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
@@ -470,8 +461,7 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 		FailNoExistPostForm(c, "network_name")
 		return
 	}
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -519,8 +509,7 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -567,8 +556,7 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 
 	mqURL := api.TConfig.RabbitMQ.URL
 
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
@@ -763,16 +751,14 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 
 	if len(users) > 0 {
 		for _, v := range users {
-			err := um.AddIPFSNetworkForUser(v, networkName)
-			if err != nil {
+			if err := um.AddIPFSNetworkForUser(v, networkName); err != nil {
 				api.LogError(err, NetworkCreationError)
 				FailOnError(c, err)
 				return
 			}
 		}
 	} else {
-		err := um.AddIPFSNetworkForUser(AdminAddress, networkName)
-		if err != nil {
+		if err := um.AddIPFSNetworkForUser(AdminAddress, networkName); err != nil {
 			api.LogError(err, NetworkCreationError)
 			FailOnError(c, err)
 			return
@@ -844,8 +830,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 		return
 	}
 
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
 		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -30,7 +30,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -58,14 +58,14 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 
 	qm, err := queue.Initialize(queue.IpfsPinQueue, mqConnectionURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnServerError(c, err)
 		return
 	}
 
 	err = qm.PublishMessageWithExchange(ip, queue.PinExchange)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueuePublishError)
 		FailOnServerError(c, err)
 		return
 	}
@@ -88,7 +88,7 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 	}
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -96,20 +96,20 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
 	key := c.Param("key")
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	sizeInBytes, err := manager.GetObjectFileSizeInBytes(key)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSObjectStatError)
 		FailOnError(c, err)
 		return
 	}
@@ -136,7 +136,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -155,18 +155,20 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 
 	miniManager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, MinioConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	fileHandler, err := c.FormFile("file")
 	if err != nil {
+		// user error, do not log
 		FailOnError(c, err)
 		return
 	}
 	fmt.Println("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
+		api.LogError(err, FileOpenError)
 		FailOnError(c, err)
 		return
 	}
@@ -177,7 +179,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	fmt.Println("storing file in minio")
 	_, err = miniManager.PutObject(FilesUploadBucket, objectName, openFile, fileHandler.Size, minio.PutObjectOptions{})
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, MinioPutError)
 		FailOnError(c, err)
 		return
 	}
@@ -191,14 +193,13 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	}
 	qm, err := queue.Initialize(queue.IpfsFileQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 	// we don't use an exchange for file publishes so that rabbitmq distributes round robin
-	err = qm.PublishMessage(ifp)
-	if err != nil {
-		api.Logger.Error(err)
+	if err = qm.PublishMessage(ifp); err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -223,6 +224,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -242,20 +244,20 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
 
 	ipfsManager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	qm, err := queue.Initialize(queue.DatabaseFileAddQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
@@ -264,18 +266,20 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	// fetch the file, and create a handler to interact with it
 	fileHandler, err := c.FormFile("file")
 	if err != nil {
+		// user error, do not log
 		FailOnError(c, err)
 		return
 	}
 
 	file, err := fileHandler.Open()
 	if err != nil {
+		api.LogError(err, FileOpenError)
 		FailOnError(c, err)
 		return
 	}
 	resp, err := ipfsManager.Add(file)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSAddError)
 		FailOnError(c, err)
 		return
 	}
@@ -286,10 +290,8 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		UserName:         username,
 		NetworkName:      networkName,
 	}
-	fmt.Printf("+%v\n", dfa)
-	err = qm.PublishMessage(dfa)
-	if err != nil {
-		api.Logger.Error(err)
+	if err = qm.PublishMessage(dfa); err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -303,13 +305,12 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 
 	qm, err = queue.Initialize(queue.IpfsPinQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
-	err = qm.PublishMessageWithExchange(pin, queue.PinExchange)
-	if err != nil {
-		api.Logger.Error(err)
+	if err = qm.PublishMessageWithExchange(pin, queue.PinExchange); err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -332,13 +333,15 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 	}
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
+		return
 	}
 
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
@@ -350,13 +353,13 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 	}
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	err = manager.PublishPubSubMessage(topic, message)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSPubSubPublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -380,8 +383,9 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 	}
 	err := CheckAccessForPrivateNetwork(username, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
+		return
 	}
 	rm := queue.IPFSPinRemoval{
 		ContentHash: hash,
@@ -391,13 +395,13 @@ func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 	mqConnectionURL := api.TConfig.RabbitMQ.URL
 	qm, err := queue.Initialize(queue.IpfsPinRemovalQueue, mqConnectionURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 	err = qm.PublishMessageWithExchange(rm, queue.PinRemovalExchange)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -422,23 +426,22 @@ func (api *API) getLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 		FailNoExistPostForm(c, "network_name")
 		return
 	}
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
-		api.Logger.Warn(err)
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
 	// initialize a connection toe the local ipfs node
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
@@ -446,7 +449,7 @@ func (api *API) getLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 	// WARNING: THIS COULD BE A VERY LARGE LIST
 	pinInfo, err := manager.Shell.Pins()
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSPinParseError)
 		FailOnError(c, err)
 		return
 	}
@@ -469,7 +472,7 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	}
 	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -477,20 +480,20 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
 	key := c.Param("key")
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	stats, err := manager.ObjectStat(key)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSObjectStatError)
 		FailOnError(c, err)
 		return
 	}
@@ -518,26 +521,27 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
 	hash := c.Param("hash")
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	present, err := manager.ParseLocalPinsForHash(hash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSPinParseError)
 		FailOnError(c, err)
 		return
 	}
@@ -565,7 +569,7 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -573,7 +577,7 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	qm, err := queue.Initialize(queue.IpnsEntryQueue, mqURL, true, false)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
@@ -605,36 +609,33 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 
 	ownsKey, err := um.CheckIfKeyOwnedByUser(ethAddress, key)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, KeySearchError)
 		FailOnError(c, err)
 		return
 	}
 
 	if !ownsKey {
-		api.Logger.Warnf("user %s attempting to generate IPNS entry unowned key", ethAddress)
-		FailOnError(c, errors.New("attempting to generate IPNS entry unowned key"))
+		err = fmt.Errorf("unauthorized access to key by user %s", ethAddress)
+		api.LogError(err, KeyUseError)
+		FailOnError(c, err)
 		return
 	}
 
 	resolve, err := strconv.ParseBool(resolveString)
 	if err != nil {
+		// user error, dont log
 		FailOnError(c, err)
 		return
 	}
 	lifetime, err := time.ParseDuration(lifetimeStr)
 	if err != nil {
+		// user error, dont log
 		FailOnError(c, err)
 		return
 	}
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		FailOnError(c, err)
-		return
-	}
-	keyID, err := um.GetKeyIDByName(ethAddress, key)
-	fmt.Println("using key id of ", keyID)
-	if err != nil {
-		api.Logger.Error(err)
+		// user error, dont log
 		FailOnError(c, err)
 		return
 	}
@@ -647,9 +648,8 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 		NetworkName: networkName,
 		UserName:    ethAddress,
 	}
-	err = qm.PublishMessage(ipnsUpdate)
-	if err != nil {
-		api.Logger.Error(err)
+	if err := qm.PublishMessage(ipnsUpdate); err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -711,13 +711,13 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 	for k, v := range bPeers {
 		addr, err := utils.GenerateMultiAddrFromString(v)
 		if err != nil {
-			api.Logger.Error(err)
+			// this is entirely on the user, so lets not bother logging as it will just make noise
 			FailOnError(c, err)
 			return
 		}
 		valid, err := utils.ParseMultiAddrForIPFSPeer(addr)
 		if err != nil {
-			api.Logger.Error(err)
+			// this is entirely on the user, so lets not bother logging as it will just make noise
 			FailOnError(c, err)
 			return
 		}
@@ -728,18 +728,18 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 		}
 		addr, err = utils.GenerateMultiAddrFromString(nodeAddresses[k])
 		if err != nil {
-			api.Logger.Error(err)
+			// this is entirely on the user, so lets not bother logging as it will just make noise
 			FailOnError(c, err)
 			return
 		}
 		valid, err = utils.ParseMultiAddrForIPFSPeer(addr)
 		if err != nil {
-			api.Logger.Error(err)
+			// this is entirely on the user, so lets not bother logging as it will just make noise
 			FailOnError(c, err)
 			return
 		}
 		if !valid {
-			api.Logger.Errorf("provided peer %s is not a valid ipfs peer", addr)
+			// this is entirely on the user, so lets not bother logging as it will just make noise
 			FailOnError(c, fmt.Errorf("provided peer %s is not a valid ipfs peer", addr))
 			return
 		}
@@ -755,7 +755,7 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 	manager := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	network, err := manager.CreateHostedPrivateNetwork(networkName, apiURL, swarmKey, args, users)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, NetworkCreationError)
 		FailOnError(c, err)
 		return
 	}
@@ -765,7 +765,7 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 		for _, v := range users {
 			err := um.AddIPFSNetworkForUser(v, networkName)
 			if err != nil {
-				api.Logger.Error(err)
+				api.LogError(err, NetworkCreationError)
 				FailOnError(c, err)
 				return
 			}
@@ -773,7 +773,7 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 	} else {
 		err := um.AddIPFSNetworkForUser(AdminAddress, networkName)
 		if err != nil {
-			api.Logger.Error(err)
+			api.LogError(err, NetworkCreationError)
 			FailOnError(c, err)
 			return
 		}
@@ -800,7 +800,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	manager := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	net, err := manager.GetNetworkByName(netName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, NetworkSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -821,7 +821,7 @@ func (api *API) getAuthorizedPrivateNetworks(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	networks, err := um.GetPrivateIPFSNetworksForUser(ethAddress)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -846,7 +846,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 
 	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
 	if err != nil {
-		api.Logger.Warn(err)
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -854,7 +854,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 	um := models.NewUploadManager(api.DBM.DB)
 	uploads, err := um.FindUploadsByNetwork(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, UploadSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -877,9 +877,8 @@ func (api *API) downloadContentHashForPrivateNetwork(c *gin.Context) {
 
 	ethAddress := GetAuthenticatedUserFromContext(c)
 
-	err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB)
-	if err != nil {
-		api.Logger.Warn(err)
+	if err := CheckAccessForPrivateNetwork(ethAddress, networkName, api.DBM.DB); err != nil {
+		api.LogError(err, PrivateNetworkAccessError)
 		FailOnError(c, err)
 		return
 	}
@@ -898,7 +897,7 @@ func (api *API) downloadContentHashForPrivateNetwork(c *gin.Context) {
 	im := models.NewHostedIPFSNetworkManager(api.DBM.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, APIURLCheckError)
 		FailOnError(c, err)
 		return
 	}
@@ -908,21 +907,21 @@ func (api *API) downloadContentHashForPrivateNetwork(c *gin.Context) {
 	// initialize our connection to IPFS
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSConnectionError)
 		FailOnError(c, err)
 		return
 	}
 	// read the contents of the file
 	reader, err := manager.Shell.Cat(contentHash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSCatError)
 		FailOnError(c, err)
 		return
 	}
 	// get the size of hte file in bytes
 	sizeInBytes, err := manager.GetObjectFileSizeInBytes(contentHash)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, IPFSObjectStatError)
 		FailOnError(c, err)
 		return
 	}
@@ -956,7 +955,7 @@ func (api *API) downloadContentHashForPrivateNetwork(c *gin.Context) {
 	api.Logger.WithFields(log.Fields{
 		"service": "api",
 		"user":    ethAddress,
-	}).Info("private ipfs content download requested")
+	}).Info("private ipfs content download served")
 
 	// send them the file
 	c.DataFromReader(200, int64(sizeInBytes), contentType, reader, extraHeaders)

--- a/api/utils.go
+++ b/api/utils.go
@@ -11,6 +11,7 @@ import (
 	jwt "github.com/appleboy/gin-jwt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
 )
 
 var nilTime time.Time
@@ -86,4 +87,12 @@ func GetAuthenticatedUserFromContext(c *gin.Context) string {
 func Respond(c *gin.Context, status int, body gin.H) {
 	body["code"] = status
 	c.JSON(status, body)
+}
+
+// LogError is a wrapper used by the API to handle logging of errors
+func (api *API) LogError(err error, message string) {
+	api.Logger.WithFields(log.Fields{
+		"service": api.Service,
+		"error":   err.Error(),
+	}).Error(message)
 }


### PR DESCRIPTION
## :construction_worker: Purpose
Cleans up API error logging
Starts foundation for TEMPORAL wide logging cleanup
Any "user generated" errors, such as incorrect key types, etc.. aren't logged
Logs will now be much easier to parse

## :rocket: Changes
Generic error messages for common errors were added. These are currently used as the "message" included with our error logs
Names have been setup to become their own types later down the line, with interfaces adhering to `error` type
Inlined a few functions with discarded return values

## :warning: Breaking Changes
None
