### PR TITLE
scripts: changed cmd invocation from Temporal to temporal

### DIFF
--- a/setup/scripts/temporal_manager.sh
+++ b/setup/scripts/temporal_manager.sh
@@ -16,31 +16,31 @@ case "$1" in
         temporal api
         ;;
     queue-dfa)
-        temporal queue-dfa
+        temporal queue dfa
         ;;
     ipfs-pin-queue)
-        temporal ipfs-pin-queue
+        temporal queue ipfs-pin
         ;;
     ipfs-file-queue)
-        temporal ipfs-file-queue
+        temporal queue ipfs-file
         ;;
     pin-payment-confirmation-queue)
-        temporal pin-payment-confirmation-queue
+        temporal queue pin-payment-confirmation
         ;;
     pin-payment-submission-queue)
-        temporal pin-payment-submission-queue
+        temporal queue pin-payment-submission
         ;;
     email-send-queue)
-        temporal email-send-queue
+        temporal queue email-send
         ;;
     ipns-entry-queue)
-        temporal ipns-entry-queue
+        temporal queue ipns-entry
         ;;
     ipfs-key-creation-queue)
-        temporal ipfs-key-creation-queue
+        temporal queue ipfs-key-creation
         ;;
     ipfs-cluster-queue)
-        temporal ipfs-cluster-queue
+        temporal queue ipfs-cluster
         ;;
     migrate)
         temporal migrate

--- a/setup/scripts/temporal_manager.sh
+++ b/setup/scripts/temporal_manager.sh
@@ -13,37 +13,37 @@ export CONFIG_DAG
 case "$1" in
 
     api)
-        Temporal api
+        temporal api
         ;;
     queue-dfa)
-        Temporal queue-dfa
+        temporal queue-dfa
         ;;
     ipfs-pin-queue)
-        Temporal ipfs-pin-queue
+        temporal ipfs-pin-queue
         ;;
     ipfs-file-queue)
-        Temporal ipfs-file-queue
+        temporal ipfs-file-queue
         ;;
     pin-payment-confirmation-queue)
-        Temporal pin-payment-confirmation-queue
+        temporal pin-payment-confirmation-queue
         ;;
     pin-payment-submission-queue)
-        Temporal pin-payment-submission-queue
+        temporal pin-payment-submission-queue
         ;;
     email-send-queue)
-        Temporal email-send-queue
+        temporal email-send-queue
         ;;
     ipns-entry-queue)
-        Temporal ipns-entry-queue
+        temporal ipns-entry-queue
         ;;
     ipfs-key-creation-queue)
-        Temporal ipfs-key-creation-queue
+        temporal ipfs-key-creation-queue
         ;;
     ipfs-cluster-queue)
-        Temporal ipfs-cluster-queue
+        temporal ipfs-cluster-queue
         ;;
     migrate)
-        Temporal migrate
+        temporal migrate
         ;;
     *)
         echo "[ERROR] Invalid command"

--- a/setup/scripts/temporal_service_monitoring.sh
+++ b/setup/scripts/temporal_service_monitoring.sh
@@ -4,7 +4,7 @@
 case "$1" in
 
     api)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal api" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal api" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -12,7 +12,7 @@ case "$1" in
         fi
         ;;
     queue-dfa)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue dfa" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue dfa" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -20,7 +20,7 @@ case "$1" in
         fi
         ;;
     ipfs-pin-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-pin" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-pin" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -28,7 +28,7 @@ case "$1" in
         fi
         ;;
     ipfs-file-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-file" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-file" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -36,7 +36,7 @@ case "$1" in
         fi
         ;;
     pin-payment-confirmation-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue pin-payment-confirmation" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue pin-payment-confirmation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -44,7 +44,7 @@ case "$1" in
         fi
         ;;
     email-send-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue email-send" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue email-send" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -52,7 +52,7 @@ case "$1" in
         fi
         ;;
     ipns-entry-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipns-entry" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipns-entry" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -60,7 +60,7 @@ case "$1" in
         fi
         ;;
     ipfs-key-creation-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-key-creation" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-key-creation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -68,7 +68,7 @@ case "$1" in
         fi
         ;;
     ipfs-cluster-queue)
-        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-cluster" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-cluster" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else

--- a/setup/scripts/temporal_service_monitoring.sh
+++ b/setup/scripts/temporal_service_monitoring.sh
@@ -4,7 +4,7 @@
 case "$1" in
 
     api)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal api" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal api" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -12,7 +12,7 @@ case "$1" in
         fi
         ;;
     queue-dfa)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal queue-dfa" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue dfa" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -20,7 +20,7 @@ case "$1" in
         fi
         ;;
     ipfs-pin-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-pin-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-pin" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -28,7 +28,7 @@ case "$1" in
         fi
         ;;
     ipfs-file-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-file-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-file" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -36,7 +36,7 @@ case "$1" in
         fi
         ;;
     pin-payment-confirmation-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal pin-payment-confirmation-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue pin-payment-confirmation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -44,7 +44,7 @@ case "$1" in
         fi
         ;;
     email-send-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal email-send-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue email-send" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -52,7 +52,7 @@ case "$1" in
         fi
         ;;
     ipns-entry-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipns-entry-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipns-entry" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -60,7 +60,7 @@ case "$1" in
         fi
         ;;
     ipfs-key-creation-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-key-creation-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-key-creation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -68,7 +68,7 @@ case "$1" in
         fi
         ;;
     ipfs-cluster-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-cluster-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3}' | grep "temporal queue ipfs-cluster" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else


### PR DESCRIPTION
## :construction_worker: Purpose
`Temporal` command was renamed to `temporal` scripts updated accordingly


## :rocket: Changes
Within the temporal monitoring and management scripts, `Temporal` was changed to `temporal`
Within the monitoring scripts, the queue names to grep for were also updated

## :warning: Breaking Changes
None, monitoring systems will still work as designed

