### PR TITLE
API Content Hash Input Validation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,12 +34,13 @@ type API struct {
 	TConfig *config.TemporalConfig
 	DBM     *database.DatabaseManager
 	Logger  *log.Logger
+	Service string
 }
 
 // Initialize is used ot initialize our API service
 func Initialize(cfg *config.TemporalConfig, logMode bool) (*API, error) {
 	// initialize an empty api struct
-	api := API{}
+	api := API{Service: "api"}
 	// setup logging
 	err := api.setupLogging()
 	if err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,74 @@
+package api
+
+const (
+	// IPFSConnectionError is an error used for ipfs connection failures
+	IPFSConnectionError = "failed to connect to ipfs"
+	// PrivateNetworkAccessError is used for invalid access to private networks
+	PrivateNetworkAccessError = "invalid access to private netowrk"
+	// APIURLCheckError is an error ussed when failing to retrieve an api url
+	APIURLCheckError = "failed to get api url"
+	// IPFSCatError is an error used when failing to can an ipfs file
+	IPFSCatError = "failed to execute ipfs cat"
+	// IPFSObjectStatError is an error used when failure to execute object stat occurs
+	IPFSObjectStatError = "failed to execute ipfs object stat"
+	// IPFSPubSubPublishError is an error message used whe nfailing to publish pubsub msgs
+	IPFSPubSubPublishError = "failed to publish pubsub message"
+	// UploadSearchError is a error used when searching for uploads fails
+	UploadSearchError = "failed to search for uploads in database"
+	// NetworkSearchError is an error used when searching for networks fail
+	NetworkSearchError = "faild to search for networks"
+	// NetworkCreationError is an error used when creating networks in database fail
+	NetworkCreationError = "failed to create network"
+	// QueueInitializationError is an error used when failing to connect to the queue
+	QueueInitializationError = "failed to initialize queue"
+	// QueuePublishError is a message used when failing to publish to queue
+	QueuePublishError = "failed to publish message to queue"
+	// KeySearchError is an error used when failing to search for a key
+	KeySearchError = "failed to search for key"
+	// KeyUseError is an error used when attempting to use a key the user down ot own
+	KeyUseError = "user does not own key"
+	// IPFSPinParseError is an error used when failure to parse ipfs pins occurs
+	IPFSPinParseError = "failed to parse ipfs pins"
+	// IPFSAddError is an error used when failing to add a file to ipfs
+	IPFSAddError = "failed to add file to ipfs"
+	// FileOpenError is an error used when failing to open a file
+	FileOpenError = "failed to open file"
+	// MinioPutError is an error used when storing a file in minio
+	MinioPutError = "failed to store object in minio"
+	// MinioConnectionError is an error used when connecting to minio
+	MinioConnectionError = "failed to connect to minio"
+	// MinioBucketCreationError is an error used when creating a minio bucket
+	MinioBucketCreationError = "failed to create minio bucket"
+	// IPFSMultiHashGenerationError is an error used when calculating an ipfs multihash
+	IPFSMultiHashGenerationError = "failed to generate ipfs multihash"
+	// IPFSClusterStatusError is a error used when getting the status of ipfs cluster
+	IPFSClusterStatusError = "failed to get ipfs cluster status"
+	// IPFSClusterConnectionError is an error used when connecting to ipfs cluster
+	IPFSClusterConnectionError = "failed to connect to IPFS cluster"
+	// IPFSClusterPinRemovalError is an error used when failing to remove a pin from the cluster
+	IPFSClusterPinRemovalError = "failed to remove pin from cluster"
+	// DNSLinkManagerError is an error used when creating a dns link manager
+	DNSLinkManagerError = "failed to create dnslink manager"
+	// DNSLinkEntryError is an error used when creating dns link entries
+	DNSLinkEntryError = "failed to create dns link entry"
+	// PaymentCreationError is an error used when creating payments
+	PaymentCreationError = "failed to create payment"
+	// PaymentMessageSignError is an error used when signing payment messages
+	PaymentMessageSignError = "failed to sign payment message"
+	// PaymentSignerGenerationError is an error used when generating the payment signer
+	PaymentSignerGenerationError = "failed to generate payment signer"
+	// EthAddressSearchError is an error used when searching for an eth address
+	EthAddressSearchError = "failed to search for eth address"
+	// PinCostCalculationError is an error message used when calculating pin costs
+	PinCostCalculationError = "failed to calculate pin cost"
+	// PaymentSearchError is an error used when searching for payment
+	PaymentSearchError = "failed to search for payment"
+	// EthAddressChangeError is an error used when changing your eth address
+	EthAddressChangeError = "failed to changing eth address"
+	// DuplicateKeyCreationError is an error used when creating a key of the same name
+	DuplicateKeyCreationError = "key name already exists"
+	// UserAccountCreationError is an error used when creating a user account
+	UserAccountCreationError = "failed to create user account"
+	// PasswordChangeError is an error used when changing your password
+	PasswordChangeError = "failed to change password"
+)

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -36,18 +35,14 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	suceeded, err := um.ChangePassword(username, oldPassword, newPassword)
 	if err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"user":    username,
-			"error":   err.Error(),
-		}).Warn("password change failed")
+		api.LogError(err, PasswordChangeError)
 		FailOnError(c, err)
 		return
 	}
 	if !suceeded {
-		msg := fmt.Sprintf("password changed failed for user %s to due an unspecified error", username)
-		api.Logger.Error(msg)
-		FailOnError(c, errors.New("password change failed but no error occured"))
+		err = fmt.Errorf("password changed failed for user %s to due an unspecified error", username)
+		api.LogError(err, PasswordChangeError)
+		FailOnError(c, err)
 		return
 	}
 
@@ -88,11 +83,7 @@ func (api *API) registerUserAccount(c *gin.Context) {
 	userManager := models.NewUserManager(api.DBM.DB)
 	userModel, err := userManager.NewUserAccount(ethAddress, username, password, email, false)
 	if err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"error":   err.Error(),
-			"user":    username,
-		}).Error("user account registration failed")
+		api.LogError(err, UserAccountCreationError)
 		FailOnError(c, err)
 		return
 	}
@@ -122,6 +113,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	case "ed25519":
 		break
 	default:
+		// user error, do not log
 		err := fmt.Errorf("%s is invalid key type must be rsa, or ed25519", keyType)
 		FailOnError(c, err)
 		return
@@ -141,10 +133,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	keys, err := um.GetKeysForUser(username)
 	if err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"error":   err.Error(),
-		}).Error("failed to retrieve keys for user")
+		api.LogError(err, KeySearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -152,10 +141,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	for _, v := range keys["key_names"] {
 		if v == keyNamePrefixed {
 			err = fmt.Errorf("key with name already exists")
-			api.Logger.WithFields(log.Fields{
-				"service": "api",
-				"error":   err.Error(),
-			}).Error("user attempting to create duplicate key")
+			api.LogError(err, DuplicateKeyCreationError)
 			FailOnError(c, err)
 			return
 		}
@@ -178,22 +164,13 @@ func (api *API) createIPFSKey(c *gin.Context) {
 
 	qm, err := queue.Initialize(queue.IpfsKeyCreationQueue, mqConnectionURL, true, false)
 	if err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"user":    username,
-			"error":   err.Error(),
-		}).Error("failed to initialize queue")
+		api.LogError(err, QueueInitializationError)
 		FailOnError(c, err)
 		return
 	}
 
-	err = qm.PublishMessageWithExchange(key, queue.IpfsKeyExchange)
-	if err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"user":    username,
-			"error":   err.Error(),
-		}).Error("failed to publish message")
+	if err = qm.PublishMessageWithExchange(key, queue.IpfsKeyExchange); err != nil {
+		api.LogError(err, QueuePublishError)
 		FailOnError(c, err)
 		return
 	}
@@ -213,8 +190,7 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 	um := models.NewUserManager(api.DBM.DB)
 	keys, err := um.GetKeysForUser(ethAddress)
 	if err != nil {
-		msg := fmt.Sprintf("key fetch for user %s failed due to error: %s", ethAddress, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, KeySearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -237,11 +213,7 @@ func (api *API) changeEthereumAddress(c *gin.Context) {
 	}
 	um := models.NewUserManager(api.DBM.DB)
 	if _, err := um.ChangeEthereumAddress(username, ethAddress); err != nil {
-		api.Logger.WithFields(log.Fields{
-			"service": "api",
-			"user":    username,
-			"error":   err.Error(),
-		}).Info("ethereum address change failed")
+		api.LogError(err, EthAddressChangeError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/RTradeLtd/Temporal/models"
@@ -15,8 +14,6 @@ var dev = false
 func (api *API) getUploadsFromDatabase(c *gin.Context) {
 	authenticatedUser := GetAuthenticatedUserFromContext(c)
 	if authenticatedUser != AdminAddress {
-		msg := fmt.Sprintf("user %s attempted unauthorized access to get uploads from database admin route", authenticatedUser)
-		api.Logger.Warn(msg)
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -24,8 +21,7 @@ func (api *API) getUploadsFromDatabase(c *gin.Context) {
 	// fetch the uplaods
 	uploads, err := um.GetUploads()
 	if err != nil {
-		msg := fmt.Sprintf("get uploads from database failed due to the following error: %s", err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, UploadSearchError)
 		FailOnError(c, err)
 		return
 	}
@@ -50,8 +46,7 @@ func (api *API) getUploadsForAddress(c *gin.Context) {
 	// fetch all uploads for that address
 	uploads, err := um.GetUploadsForUser(queryUser)
 	if err != nil {
-		msg := fmt.Sprintf("get uploads from database for user %s failed due to the following error: %s", queryUser, err.Error())
-		api.Logger.Error(msg)
+		api.LogError(err, UploadSearchError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
+	gocid "github.com/ipfs/go-cid"
 	"github.com/jinzhu/gorm"
 	minio "github.com/minio/minio-go"
 	log "github.com/sirupsen/logrus"
@@ -56,6 +57,10 @@ func (api *API) calculateIPFSFileHash(c *gin.Context) {
 func (api *API) calculatePinCost(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	holdTime := c.Param("holdtime")
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
@@ -114,6 +119,10 @@ func (api *API) calculateFileCost(c *gin.Context) {
 // CreatePinPayment is used to create a signed message for a pin payment
 func (api *API) createPinPayment(c *gin.Context) {
 	contentHash := c.Param("hash")
+	if _, err := gocid.Decode(contentHash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	username := GetAuthenticatedUserFromContext(c)
 	holdTime, exists := c.GetPostForm("hold_time")
 	if !exists {

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/RTradeLtd/Temporal/models"
 	"github.com/RTradeLtd/Temporal/queue"
+	gocid "github.com/ipfs/go-cid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/RTradeLtd/Temporal/rtns/dlink"
@@ -22,6 +23,10 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 	hash, present := c.GetPostForm("hash")
 	if !present {
 		FailNoExistPostForm(c, "hash")
+		return
+	}
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
 		return
 	}
 	lifetimeStr, present := c.GetPostForm("life_time")

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -26,16 +26,15 @@ func (api *API) makeBucket(c *gin.Context) {
 	endpoint := fmt.Sprintf("%s:%s", api.TConfig.MINIO.Connection.IP, api.TConfig.MINIO.Connection.Port)
 	manager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, true)
 	if err != nil {
-		api.Logger.Error(err)
+		api.LogError(err, MinioConnectionError)
 		FailOnError(c, err)
 		return
 	}
 
 	args := make(map[string]string)
 	args["name"] = bucketName
-	err = manager.MakeBucket(args)
-	if err != nil {
-		api.Logger.Error(err)
+	if err = manager.MakeBucket(args); err != nil {
+		api.LogError(err, MinioBucketCreationError)
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RTradeLtd/Temporal/mini"
 	"github.com/RTradeLtd/Temporal/utils"
+	gocid "github.com/ipfs/go-cid"
 	"github.com/minio/minio-go"
 	log "github.com/sirupsen/logrus"
 
@@ -51,6 +52,10 @@ func (api *API) calculateContentHashForFile(c *gin.Context) {
 // PinHashLocally is used to pin a hash to the local ipfs node
 func (api *API) pinHashLocally(c *gin.Context) {
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	username := GetAuthenticatedUserFromContext(c)
 	holdTimeInMonths, exists := c.GetPostForm("hold_time")
 	if !exists {
@@ -97,6 +102,10 @@ func (api *API) pinHashLocally(c *gin.Context) {
 func (api *API) getFileSizeInBytesForObject(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	key := c.Param("key")
+	if _, err := gocid.Decode(key); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -330,6 +339,10 @@ func (api *API) removePinFromLocalHost(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	mqURL := api.TConfig.RabbitMQ.URL
 
 	qm, err := queue.Initialize(queue.IpfsPinRemovalQueue, mqURL, true, false)
@@ -393,6 +406,10 @@ func (api *API) getLocalPins(c *gin.Context) {
 func (api *API) getObjectStatForIpfs(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	key := c.Param("key")
+	if _, err := gocid.Decode(key); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -422,6 +439,10 @@ func (api *API) checkLocalNodeForPin(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -459,6 +480,10 @@ func (api *API) downloadContentHash(c *gin.Context) {
 
 	// get the content hash that is to be downloaded
 	contentHash := c.Param("hash")
+	if _, err := gocid.Decode(contentHash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	// initialize our connection to IPFS
 	manager, err := rtfs.Initialize("", "")
 	if err != nil {

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -15,6 +15,10 @@ import (
 func (api *API) pinHashToCluster(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	holdTime, exists := c.GetPostForm("hold_time")
 	if !exists {
 		FailNoExistPostForm(c, "hold_time")
@@ -97,6 +101,10 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
 		api.LogError(err, IPFSClusterConnectionError)
@@ -125,6 +133,10 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	// initialize a connection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {
@@ -156,6 +168,10 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	// initialize a connection to the cluster
 	manager, err := rtfs_cluster.Initialize("", "")
 	if err != nil {

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/RTradeLtd/Temporal/mini"
 	"github.com/RTradeLtd/Temporal/queue"
 	"github.com/RTradeLtd/Temporal/rtfs"
+	gocid "github.com/ipfs/go-cid"
 	minio "github.com/minio/minio-go"
 	log "github.com/sirupsen/logrus"
 
@@ -35,7 +36,10 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
-
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	holdTimeInMonths, exists := c.GetPostForm("hold_time")
 	if !exists {
 		FailNoExistPostForm(c, "hold_time")
@@ -99,6 +103,10 @@ func (api *API) getFileSizeInBytesForObjectForHostedIPFSNetwork(c *gin.Context) 
 		return
 	}
 	key := c.Param("key")
+	if _, err := gocid.Decode(key); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -369,6 +377,10 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) removePinFromLocalHostForHostedIPFSNetwork(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	networkName, exists := c.GetPostForm("network_name")
 	if !exists {
 		FailNoExistPostForm(c, "network_name")
@@ -475,6 +487,10 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	key := c.Param("key")
+	if _, err := gocid.Decode(key); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -522,6 +538,10 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {
 		api.LogError(err, IPFSConnectionError)
@@ -572,6 +592,10 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 	hash, present := c.GetPostForm("hash")
 	if !present {
 		FailNoExistPostForm(c, "hash")
+		return
+	}
+	if _, err := gocid.Decode(hash); err != nil {
+		FailOnError(c, err)
 		return
 	}
 	lifetimeStr, present := c.GetPostForm("life_time")
@@ -888,7 +912,10 @@ func (api *API) downloadContentHashForPrivateNetwork(c *gin.Context) {
 	}
 	// get the content hash that is to be downloaded
 	contentHash := c.Param("hash")
-
+	if _, err := gocid.Decode(contentHash); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	// initialize our connection to IPFS
 	manager, err := rtfs.Initialize("", apiURL)
 	if err != nil {

--- a/api/utils.go
+++ b/api/utils.go
@@ -11,6 +11,7 @@ import (
 	jwt "github.com/appleboy/gin-jwt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
 )
 
 var nilTime time.Time
@@ -86,4 +87,12 @@ func GetAuthenticatedUserFromContext(c *gin.Context) string {
 func Respond(c *gin.Context, status int, body gin.H) {
 	body["code"] = status
 	c.JSON(status, body)
+}
+
+// LogError is a wrapper used by the API to handle logging of errors
+func (api *API) LogError(err error, message string) {
+	api.Logger.WithFields(log.Fields{
+		"service": api.Service,
+		"error":   err.Error(),
+	}).Error(message)
 }

--- a/setup/scripts/temporal_manager.sh
+++ b/setup/scripts/temporal_manager.sh
@@ -13,37 +13,37 @@ export CONFIG_DAG
 case "$1" in
 
     api)
-        Temporal api
+        temporal api
         ;;
     queue-dfa)
-        Temporal queue-dfa
+        temporal queue dfa
         ;;
     ipfs-pin-queue)
-        Temporal ipfs-pin-queue
+        temporal queue ipfs-pin
         ;;
     ipfs-file-queue)
-        Temporal ipfs-file-queue
+        temporal queue ipfs-file
         ;;
     pin-payment-confirmation-queue)
-        Temporal pin-payment-confirmation-queue
+        temporal queue pin-payment-confirmation
         ;;
     pin-payment-submission-queue)
-        Temporal pin-payment-submission-queue
+        temporal queue pin-payment-submission
         ;;
     email-send-queue)
-        Temporal email-send-queue
+        temporal queue email-send
         ;;
     ipns-entry-queue)
-        Temporal ipns-entry-queue
+        temporal queue ipns-entry
         ;;
     ipfs-key-creation-queue)
-        Temporal ipfs-key-creation-queue
+        temporal queue ipfs-key-creation
         ;;
     ipfs-cluster-queue)
-        Temporal ipfs-cluster-queue
+        temporal queue ipfs-cluster
         ;;
     migrate)
-        Temporal migrate
+        temporal migrate
         ;;
     *)
         echo "[ERROR] Invalid command"

--- a/setup/scripts/temporal_service_monitoring.sh
+++ b/setup/scripts/temporal_service_monitoring.sh
@@ -4,7 +4,7 @@
 case "$1" in
 
     api)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal api" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal api" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -12,7 +12,7 @@ case "$1" in
         fi
         ;;
     queue-dfa)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal queue-dfa" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue dfa" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -20,7 +20,7 @@ case "$1" in
         fi
         ;;
     ipfs-pin-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-pin-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-pin" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -28,7 +28,7 @@ case "$1" in
         fi
         ;;
     ipfs-file-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-file-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-file" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -36,7 +36,7 @@ case "$1" in
         fi
         ;;
     pin-payment-confirmation-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal pin-payment-confirmation-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue pin-payment-confirmation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -44,7 +44,7 @@ case "$1" in
         fi
         ;;
     email-send-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal email-send-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue email-send" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -52,7 +52,7 @@ case "$1" in
         fi
         ;;
     ipns-entry-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipns-entry-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipns-entry" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -60,7 +60,7 @@ case "$1" in
         fi
         ;;
     ipfs-key-creation-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-key-creation-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-key-creation" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else
@@ -68,7 +68,7 @@ case "$1" in
         fi
         ;;
     ipfs-cluster-queue)
-        PID=$(pgrep -ax Temporal | awk '{print $2" "$3}' | grep "Temporal ipfs-cluster-queue" | grep -iv grep | awk '{print $2}')
+        PID=$(pgrep -ax temporal | awk '{print $2" "$3" "$4}' | grep "temporal queue ipfs-cluster" | grep -iv grep | awk '{print $2}')
         if [[ "$PID" == "" ]]; then
             echo 0
         else


### PR DESCRIPTION
## :construction_worker: Purpose
Validate content hashes being given to us through the API. Previously we would consider anything provided as a hash as valid data. This would get passed further down the line of processing, which is suboptimal. From a security standpoint, this is very dangerous. By validating content hashes, we prevent invalid data from being considered valid


## :rocket: Changes
Anytime an API call is made that provides a content hash as input, we validate it using `go-cid`.


## :warning: Breaking Changes
No, `go-cid` was already a dependent package.

