### PR TITLE
Refined API Get IPFS Keys Call

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -71,4 +71,6 @@ const (
 	UserAccountCreationError = "failed to create user account"
 	// PasswordChangeError is an error used when changing your password
 	PasswordChangeError = "failed to change password"
+	// NoKeyError is an error message given to a user when they search for keys, but have none
+	NoKeyError = "no keys"
 )

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -194,7 +195,11 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-
+	// if the user has no keys, fail with an error
+	if len(keys["key_names"]) == 0 || len(keys["key_ids"]) == 0 {
+		FailOnError(c, errors.New(NoKeyError))
+		return
+	}
 	api.Logger.WithFields(log.Fields{
 		"service": "api",
 		"user":    ethAddress,


### PR DESCRIPTION
## :construction_worker: Purpose
Previously when a user would request a list of their IPFS keys, if they had none we would consider it valid and return null data. Now instead, we return an error messaging saying they have no keys


## :rocket: Changes
Adds a new error message, adds a check during the API call which checks the length of key names, and key ids. If either one of them is zero, fail.


## :warning: Breaking Changes
None
