### PR TITLE
Configurable File Size Limit For Uploads

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -73,4 +73,6 @@ const (
 	PasswordChangeError = "failed to change password"
 	// NoKeyError is an error message given to a user when they search for keys, but have none
 	NoKeyError = "no keys"
+	// FileTooBigError is an error message given to a user when attempting to upload a file larger than our limit
+	FileTooBigError = "attempting to upload too big of a file"
 )

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -96,6 +96,10 @@ func (api *API) calculateFileCost(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
+	if err := api.FileSizeCheck(file.Size); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	holdTime, exists := c.GetPostForm("hold_time")
 	if !exists {
 		FailNoExistPostForm(c, "hold_time")
@@ -243,6 +247,10 @@ func (api *API) createFilePayment(c *gin.Context) {
 	}
 	fileHandler, err := c.FormFile("file")
 	if err != nil {
+		FailOnError(c, err)
+		return
+	}
+	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
 		FailOnError(c, err)
 		return
 	}

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -155,6 +155,10 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
+	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	fmt.Println("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
@@ -213,7 +217,10 @@ func (api *API) addFileLocally(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-
+	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	username := GetAuthenticatedUserFromContext(c)
 
 	holdTimeinMonths, present := c.GetPostForm("hold_time")

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -170,6 +170,10 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
+	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	fmt.Println("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
@@ -273,7 +277,10 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		FailOnError(c, err)
 		return
 	}
-
+	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
+		FailOnError(c, err)
+		return
+	}
 	file, err := fileHandler.Open()
 	if err != nil {
 		api.LogError(err, FileOpenError)

--- a/api/utils.go
+++ b/api/utils.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/RTradeLtd/Temporal/models"
 	"github.com/RTradeLtd/Temporal/utils"
 	jwt "github.com/appleboy/gin-jwt"
+	"github.com/c2h5oh/datasize"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	log "github.com/sirupsen/logrus"
@@ -95,4 +97,21 @@ func (api *API) LogError(err error, message string) {
 		"service": api.Service,
 		"error":   err.Error(),
 	}).Error(message)
+}
+
+// FileSizeCheck is used to check and validate the size of the uploaded file
+func (api *API) FileSizeCheck(size int64) error {
+	sizeInt, err := strconv.ParseInt(
+		api.TConfig.API.SizeLimitInGigaBytes,
+		10,
+		64,
+	)
+	if err != nil {
+		return err
+	}
+	gbInt := int64(datasize.GB.Bytes()) * sizeInt
+	if size > gbInt {
+		return errors.New(FileTooBigError)
+	}
+	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,9 @@ type TemporalConfig struct {
 			AuthKey       string `json:"auth_key"`
 			EncryptionKey string `json:"encryption_key"`
 		} `json:"sessions"`
-		RollbarToken string `json:"rollbar_token"`
-		JwtKey       string `json:"jwt_key"`
+		RollbarToken         string `json:"rollbar_token"`
+		JwtKey               string `json:"jwt_key"`
+		SizeLimitInGigaBytes string `json:"size_limit_in_giga_bytes"`
 	} `json:"api"`
 	IPFS struct {
 		APIConnection struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,10 +9,7 @@ import (
 var configPath = "../test/config.json"
 
 func TestConfig(t *testing.T) {
-	_, err := config.LoadConfig(configPath)
-	if err != nil {
+	if _, err := config.LoadConfig(configPath); err != nil {
 		t.Fatal(err)
 	}
-	//fmt.Printf("%+v\n", cfg.AWS)
-	//fmt.Printf("%+v\n", cfg.MINIO)
 }

--- a/example.config.json
+++ b/example.config.json
@@ -19,7 +19,8 @@
 			"encryption_key": "this is a test 1"
 		},
 		"rollbar_token": "....",
-		"jwt_key": "....."
+		"jwt_key": ".....",
+		"size_limit_in_giga_bytes": "2"
 	},
 	"ipfs": {
 		"api_connection": {

--- a/test/config.json
+++ b/test/config.json
@@ -19,7 +19,8 @@
 			"encryption_key": "this is a test 1"
 		},
 		"rollbar_token": "....",
-		"jwt_key": "....."
+		"jwt_key": ".....",
+		"size_limit_in_giga_bytes": "2"
 	},
 	"ipfs": {
 		"api_connection": {


### PR DESCRIPTION
## :construction_worker: Purpose
Allows restriction of the maximum size allowed for uploading files.


## :rocket: Changes
`config.json` has a `size_limit_in_giga_bytes` parameter that allows you to specify the limit
Every API call that involves uploading a file performs a check against the size of the file, and fails with an error if it is above the limit


## :warning: Breaking Changes
Yes, any API nodes need to use a new config file or else API calls uploading files will fail.