### PR TITLE
cli: create 'ipfs' sub-command

### DIFF
--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -49,81 +49,87 @@ var commands = map[string]app.Cmd{
 		Description:   "Interact with Temporal's various queue APIs",
 		ChildRequired: true,
 		Children: map[string]app.Cmd{
+			"ipfs": app.Cmd{
+				Blurb:         "interact with IPFS",
+				ChildRequired: true,
+				Children: map[string]app.Cmd{
+					"pin": app.Cmd{
+						Blurb: "",
+						Action: func(cfg config.TemporalConfig, args map[string]string) {
+							mqConnectionURL := cfg.RabbitMQ.URL
+							qm, err := queue.Initialize(queue.IpfsPinQueue, mqConnectionURL, false, true)
+							if err != nil {
+								log.Fatal(err)
+							}
+							err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
+							if err != nil {
+								log.Fatal(err)
+							}
+						},
+					},
+					"pin-removal": app.Cmd{
+						Blurb: "",
+						Action: func(cfg config.TemporalConfig, args map[string]string) {
+							mqConnectionURL := cfg.RabbitMQ.URL
+							qm, err := queue.Initialize(queue.IpfsPinRemovalQueue, mqConnectionURL, false, true)
+							if err != nil {
+								log.Fatal(err)
+							}
+							err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
+							if err != nil {
+								log.Fatal(err)
+							}
+						},
+					},
+					"file": app.Cmd{
+						Blurb: "",
+						Action: func(cfg config.TemporalConfig, args map[string]string) {
+							mqConnectionURL := cfg.RabbitMQ.URL
+							qm, err := queue.Initialize(queue.IpfsFileQueue, mqConnectionURL, false, true)
+							if err != nil {
+								log.Fatal(err)
+							}
+							err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
+							if err != nil {
+								log.Fatal(err)
+							}
+						},
+					},
+					"key-creation": app.Cmd{
+						Blurb: "",
+						Action: func(cfg config.TemporalConfig, args map[string]string) {
+							mqConnectionURL := cfg.RabbitMQ.URL
+							qm, err := queue.Initialize(queue.IpfsKeyCreationQueue, mqConnectionURL, false, true)
+							if err != nil {
+								log.Fatal(err)
+							}
+							err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
+							if err != nil {
+								log.Fatal(err)
+							}
+						},
+					},
+					"cluster": app.Cmd{
+						Blurb: "listen to cluster pin pubsub topic",
+						Action: func(cfg config.TemporalConfig, args map[string]string) {
+							mqConnectionURL := cfg.RabbitMQ.URL
+							qm, err := queue.Initialize(queue.IpfsClusterPinQueue, mqConnectionURL, false, true)
+							if err != nil {
+								log.Fatal(err)
+							}
+							err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
+							if err != nil {
+								log.Fatal(err)
+							}
+						},
+					},
+				},
+			},
 			"dfa": app.Cmd{
 				Blurb: "listen to file add requests, and add to the database",
 				Action: func(cfg config.TemporalConfig, args map[string]string) {
 					mqConnectionURL := cfg.RabbitMQ.URL
 					qm, err := queue.Initialize(queue.DatabaseFileAddQueue, mqConnectionURL, false, true)
-					if err != nil {
-						log.Fatal(err)
-					}
-					err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
-					if err != nil {
-						log.Fatal(err)
-					}
-				},
-			},
-			"ipfs-pin": app.Cmd{
-				Blurb: "",
-				Action: func(cfg config.TemporalConfig, args map[string]string) {
-					mqConnectionURL := cfg.RabbitMQ.URL
-					qm, err := queue.Initialize(queue.IpfsPinQueue, mqConnectionURL, false, true)
-					if err != nil {
-						log.Fatal(err)
-					}
-					err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
-					if err != nil {
-						log.Fatal(err)
-					}
-				},
-			},
-			"ipfs-file": app.Cmd{
-				Blurb: "",
-				Action: func(cfg config.TemporalConfig, args map[string]string) {
-					mqConnectionURL := cfg.RabbitMQ.URL
-					qm, err := queue.Initialize(queue.IpfsFileQueue, mqConnectionURL, false, true)
-					if err != nil {
-						log.Fatal(err)
-					}
-					err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
-					if err != nil {
-						log.Fatal(err)
-					}
-				},
-			},
-			"ipfs-pin-removal": app.Cmd{
-				Blurb: "",
-				Action: func(cfg config.TemporalConfig, args map[string]string) {
-					mqConnectionURL := cfg.RabbitMQ.URL
-					qm, err := queue.Initialize(queue.IpfsPinRemovalQueue, mqConnectionURL, false, true)
-					if err != nil {
-						log.Fatal(err)
-					}
-					err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
-					if err != nil {
-						log.Fatal(err)
-					}
-				},
-			},
-			"ipfs-key-creation": app.Cmd{
-				Blurb: "",
-				Action: func(cfg config.TemporalConfig, args map[string]string) {
-					mqConnectionURL := cfg.RabbitMQ.URL
-					qm, err := queue.Initialize(queue.IpfsKeyCreationQueue, mqConnectionURL, false, true)
-					if err != nil {
-						log.Fatal(err)
-					}
-					err = qm.ConsumeMessage("", args["dbPass"], args["dbURL"], args["dbUser"], &cfg)
-					if err != nil {
-						log.Fatal(err)
-					}
-				},
-			},
-			"ipfs-cluster": app.Cmd{
-				Blurb: "listen to cluster pin pubsub topic",
-				Action: func(cfg config.TemporalConfig, args map[string]string) {
-					mqConnectionURL := cfg.RabbitMQ.URL
-					qm, err := queue.Initialize(queue.IpfsClusterPinQueue, mqConnectionURL, false, true)
 					if err != nil {
 						log.Fatal(err)
 					}

--- a/setup/scripts/temporal_manager.sh
+++ b/setup/scripts/temporal_manager.sh
@@ -19,10 +19,10 @@ case "$1" in
         temporal queue dfa
         ;;
     ipfs-pin-queue)
-        temporal queue ipfs-pin
+        temporal queue ipfs pin
         ;;
     ipfs-file-queue)
-        temporal queue ipfs-file
+        temporal queue ipfs file
         ;;
     pin-payment-confirmation-queue)
         temporal queue pin-payment-confirmation
@@ -37,10 +37,10 @@ case "$1" in
         temporal queue ipns-entry
         ;;
     ipfs-key-creation-queue)
-        temporal queue ipfs-key-creation
+        temporal queue ipfs key-creation
         ;;
     ipfs-cluster-queue)
-        temporal queue ipfs-cluster
+        temporal queue ipfs cluster
         ;;
     migrate)
         temporal migrate


### PR DESCRIPTION

## :construction_worker: Purpose

Continued cleanup of temporal cli

## :rocket: Changes

ipfs-* commands are now under the 'temporal queue ipfs' tree


```
❯ ./temporal help queue ipfs
interact with IPFS

usage:

        ./temporal queue ipfs [command]

commands:

        cluster       listen to cluster pin pubsub topic
        file
        key-creation
        pin
        pin-removal
```

## :warning: Breaking Changes

CLI usage for `temporal queue ipfs-*` changed
