### PR TITLE
test: add rabbitmq to testenv, enable queue tests

### DIFF
--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -3,7 +3,6 @@ package queue_test
 import (
 	"testing"
 
-	"github.com/RTradeLtd/Temporal/config"
 	"github.com/RTradeLtd/Temporal/queue"
 )
 
@@ -11,40 +10,32 @@ const (
 	defaultConfigFile = "/home/solidity/config.json"
 	testCID           = "QmPY5iMFjNZKxRbUZZC85wXb9CFgNSyzAy1LxwL62D8VGr"
 	testEthAddress    = "0x7E4A2359c745A982a54653128085eAC69E446DE1"
+	testRabbitAddress = "amqp://127.0.0.1:5672"
 )
 
 func TestInitialize(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	cfg, err := config.LoadConfig(defaultConfigFile)
-	if err != nil {
-		t.Fatal(err)
-	}
 	type args struct {
-		queueName     string
-		connectionURL string
-		publish       bool
-		service       bool
+		queueName string
+		publish   bool
+		service   bool
 	}
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"DFAQ", args{queue.DatabaseFileAddQueue, cfg.RabbitMQ.URL, false, false}},
-		{"IPQ", args{queue.IpfsPinQueue, cfg.RabbitMQ.URL, false, false}},
-		{"IFQ", args{queue.IpfsFileQueue, cfg.RabbitMQ.URL, false, false}},
-		{"PPCQ", args{queue.PinPaymentConfirmationQueue, cfg.RabbitMQ.URL, false, false}},
-		{"PPSQ", args{queue.PinPaymentSubmissionQueue, cfg.RabbitMQ.URL, false, false}},
-		{"ESQ", args{queue.EmailSendQueue, cfg.RabbitMQ.URL, false, false}},
-		{"IEQ", args{queue.IpnsEntryQueue, cfg.RabbitMQ.URL, false, false}},
-		{"IPRQ", args{queue.IpfsPinRemovalQueue, cfg.RabbitMQ.URL, false, false}},
+		{"DFAQ", args{queue.DatabaseFileAddQueue, false, false}},
+		{"IPQ", args{queue.IpfsPinQueue, false, false}},
+		{"IFQ", args{queue.IpfsFileQueue, false, false}},
+		{"PPCQ", args{queue.PinPaymentConfirmationQueue, false, false}},
+		{"PPSQ", args{queue.PinPaymentSubmissionQueue, false, false}},
+		{"ESQ", args{queue.EmailSendQueue, false, false}},
+		{"IEQ", args{queue.IpnsEntryQueue, false, false}},
+		{"IPRQ", args{queue.IpfsPinRemovalQueue, false, false}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := queue.Initialize(tt.args.queueName, tt.args.connectionURL, tt.args.publish, tt.args.service)
-			if err != nil {
+			if _, err := queue.Initialize(tt.args.queueName,
+				testRabbitAddress, tt.args.publish, tt.args.service); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -52,16 +43,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestQueues(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	cfg, err := config.LoadConfig(defaultConfigFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	qm, err := queue.Initialize(queue.IpfsPinQueue, cfg.RabbitMQ.URL, false, false)
+	qm, err := queue.Initialize(queue.IpfsPinQueue, testRabbitAddress, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -18,3 +18,8 @@ services:
     environment:
       MINIO_ACCESS_KEY: "C03T49S17RP0APEZDK6M"
       MINIO_SECRET_KEY: "q4I9t2MN/6bAgLkbF6uyS7jtQrXuNARcyrm2vvNA"
+
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672:5672"


### PR DESCRIPTION
## :construction_worker: Purpose

Continued work towards a completely locally reproducible test environment, geared towards improved continuous integration on Travis

## :rocket: Changes

- add rabbitmq to test environment
- enable queue tests by removing the `t.Short()` skip

## :warning: Breaking Changes

none