### PR TITLE
TEM-49: use gox to cross-compile releases

### DIFF
--- a/.scripts/release.sh
+++ b/.scripts/release.sh
@@ -1,21 +1,14 @@
 #! /bin/bash
 
-# Cross-compile Temporal using xgo, injecting appropriate tags.
+# Cross-compile Temporal using gox, injecting appropriate tags.
+go get -u github.com/mitchellh/gox
 
 RELEASE=$(git describe --tags)
-TARGETS="linux/amd64,linux/386,linux/arm,darwin/amd64,windows/amd64"
+TARGETS="linux/amd64 linux/386 linux/arm darwin/amd64 windows/amd64"
 
 mkdir -p release
 
-# dest:    output folder
-# out:     output file name
-# ldflags: set build version (git tag)
-# targets: platforms to compile for (see $TARGET)
-# deps:    for ethereum, see https://github.com/ethereum/go-ethereum/wiki/Cross-compiling-Ethereum#building-ethereum
-xgo \
-  --dest="release" \
-  --out="temporal-$(git describe --tags)" \
-  --ldflags="-X main.Version=$RELEASE" \
-  --targets="$TARGETS" \
-  --deps="https://gmplib.org/download/gmp/gmp-6.0.0a.tar.bz2" \
-  ./cmd/temporal
+gox -output="release/temporal-$(git describe --tags)-{{.OS}}-{{.Arch}}" \
+    -ldflags "-X main.Version=$RELEASE" \
+    -osarch="$TARGETS" \
+    ./cmd/temporal

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:
-  - go get -u github.com/karalabe/xgo
   - make release-cli
 
 deploy:


### PR DESCRIPTION
## :construction_worker: Purpose

xgo, while great for cross-compiling c dependencies for go-ethereum, is insanely slow. Now that go-ethereum is no longer a dependency (as of #191) we can use the much faster gox project instead.

## :rocket: Changes

Switch to gox for release builds. Much faster:

```
~/go/src/github.com/RTradeLtd/Temporal V2* 1m 23s
❯ bash .scripts/release.sh
Number of parallel builds: 7

-->   windows/amd64: github.com/RTradeLtd/Temporal/cmd/temporal
-->       linux/arm: github.com/RTradeLtd/Temporal/cmd/temporal
-->    darwin/amd64: github.com/RTradeLtd/Temporal/cmd/temporal
-->       linux/386: github.com/RTradeLtd/Temporal/cmd/temporal
-->     linux/amd64: github.com/RTradeLtd/Temporal/cmd/temporal

~/go/src/github.com/RTradeLtd/Temporal V2* 7s
❯ ls release
temporal-v1.0-beta.1-127-ga270a0df-darwin-amd64      temporal-v1.0-beta.1-127-ga270a0df-linux-amd64       temporal-v1.0-beta.1-127-ga270a0df-windows-amd64.exe
temporal-v1.0-beta.1-127-ga270a0df-linux-386         temporal-v1.0-beta.1-127-ga270a0df-linux-arm
```

## :warning: Breaking Changes

none