### PR TITLE
Docker build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,9 @@ vendor:
 	git clone https://github.com/ipfs/go-ipfs.git vendor/github.com/ipfs/go-ipfs
 	( cd vendor/github.com/ipfs/go-ipfs ; git checkout $(IPFSVERSION) ; gx install --local --nofancy )
 	mv vendor/github.com/ipfs/go-ipfs/vendor/* vendor
+
+	# Remove problematic dependencies
+	find . -name test-vectors -type d -exec rm -r {} +
 	@echo "===================          done           ==================="
 
 # Build CLI binary release


### PR DESCRIPTION
## :construction_worker: Purpose

The automated docker build was having issues with a vendor'd dependency being incorrectly recognized as a submodule - this PR fixes the issue

## :rocket: Changes

Removed `test-vectors`, a non-critical dependency

## :warning: Breaking Changes

none
