### PR TITLE
queue: change db connection method

### DIFF
--- a/mail/mail.go
+++ b/mail/mail.go
@@ -33,7 +33,7 @@ func GenerateMailManager(tCfg *config.TemporalConfig) (*MailManager, error) {
 	dbURL := tCfg.Database.URL
 	dbUser := tCfg.Database.Username
 	db, err := database.OpenDBConnection(database.DBOptions{
-		User: dbUser, Password: dbPass, Address: dbURL})
+		User: dbUser, Password: dbPass, Address: dbURL, Port: "5432"})
 	if err != nil {
 		return nil, err
 	}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -240,7 +240,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 		User:           cfg.Database.Username,
 		Password:       cfg.Database.Password,
 		Address:        cfg.Database.URL,
-		Port:           cfg.Database.Password,
+		Port:           cfg.Database.Port,
 		SSLModeDisable: false,
 	})
 	if err != nil {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -236,11 +236,16 @@ func (qm *QueueManager) DeclareQueue() error {
 // Question, do we really want to ack messages that fail to be processed?
 // Perhaps the error was temporary, and we allow it to be retried?
 func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, cfg *config.TemporalConfig) error {
-	dbm, err := database.Initialize(cfg, database.DatabaseOptions{LogMode: true})
+	db, err := database.OpenDBConnection(database.DBOptions{
+		User:           cfg.Database.Username,
+		Password:       cfg.Database.Password,
+		Address:        cfg.Database.URL,
+		Port:           cfg.Database.Password,
+		SSLModeDisable: false,
+	})
 	if err != nil {
 		return err
 	}
-	db := dbm.DB
 	// ifs the queue is using an exchange, we will need to bind the queue to the exchange
 	switch qm.ExchangeName {
 	case PinRemovalExchange:

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -236,12 +236,11 @@ func (qm *QueueManager) DeclareQueue() error {
 // Question, do we really want to ack messages that fail to be processed?
 // Perhaps the error was temporary, and we allow it to be retried?
 func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, cfg *config.TemporalConfig) error {
-	db, err := database.OpenDBConnection(database.DBOptions{
-		User: dbUser, Password: dbPass, Address: dbURL})
+	dbm, err := database.Initialize(cfg, database.DatabaseOptions{LogMode: true})
 	if err != nil {
 		return err
 	}
-
+	db := dbm.DB
 	// ifs the queue is using an exchange, we will need to bind the queue to the exchange
 	switch qm.ExchangeName {
 	case PinRemovalExchange:


### PR DESCRIPTION
## :construction_worker: Purpose
Fix issue with DB initialization and the queue system


## :rocket: Changes
Use the `database.Initialize` function instead of `database.OpenDBConnection`


## :warning: Breaking Changes
None

