### PR TITLE
user: enable api access on acct signup

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -206,11 +206,14 @@ func (um *UserManager) NewUserAccount(ethAddress, username, password, email stri
 	if ethAddress != "" {
 		user.EthAddress = ethAddress
 	}
-	user.UserName = username
-	user.EnterpriseEnabled = enterpriseEnabled
-	user.HashedPassword = hex.EncodeToString(hashedPass)
-	user.EmailAddress = email
-	user.AccountEnabled = true
+	user = User{
+		UserName:          username,
+		EnterpriseEnabled: enterpriseEnabled,
+		HashedPassword:    hex.EncodeToString(hashedPass),
+		EmailAddress:      email,
+		AccountEnabled:    true,
+		APIAccess:         true,
+	}
 	if check := um.DB.Create(&user); check.Error != nil {
 		return nil, check.Error
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -203,11 +203,12 @@ func (um *UserManager) NewUserAccount(ethAddress, username, password, email stri
 	if err != nil {
 		return nil, err
 	}
-	if ethAddress != "" {
-		user.EthAddress = ethAddress
+	if ethAddress == "" {
+		ethAddress = username
 	}
 	user = User{
 		UserName:          username,
+		EthAddress:        ethAddress,
 		EnterpriseEnabled: enterpriseEnabled,
 		HashedPassword:    hex.EncodeToString(hashedPass),
 		EmailAddress:      email,

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -50,9 +50,11 @@ func TestUserManager_ChangeEthereumAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled); err != nil {
+			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			if err != nil {
 				t.Fatal(err)
 			}
+			defer um.DB.Delete(user)
 			if _, err := um.ChangeEthereumAddress(tt.args.userName, tt.args.ethAddress); err != nil {
 				t.Error(err)
 			}
@@ -87,9 +89,11 @@ func TestUserManager_ChangePassword(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled); err != nil {
+			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			if err != nil {
 				t.Fatal(err)
 			}
+			defer um.DB.Delete(user)
 			changed, err := um.ChangePassword(tt.args.userName, tt.args.password, "newpassword")
 			if err != nil {
 				t.Fatal(err)
@@ -129,9 +133,11 @@ func TestUserManager_NewAccount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled); err != nil {
+			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			if err != nil {
 				t.Fatal(err)
 			}
+			um.DB.Delete(user)
 		})
 	}
 }
@@ -164,9 +170,11 @@ func TestUserManager_SignIn(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled); err != nil {
+			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			if err != nil {
 				t.Fatal(err)
 			}
+			defer um.DB.Delete(user)
 			success, err := um.SignIn(tt.args.userName, tt.args.password)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
## :construction_worker: Purpose
User sign ups weren't triggering granting them API access, causing logins to fail after registration.


## :rocket: Changes
Whenever a new user account is created, grant them API access


## :warning: Breaking Changes
None

