### PR TITLE
API Cleanup: TEM-75, TEM-76

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -244,5 +244,5 @@ func (api *API) setupRoutes() {
 	mini.POST("/create/bucket", api.makeBucket)
 	// PROTECTED ROUTES -- END
 
-	api.l.Info("Routes initialized")
+	api.LogInfo("Routes initialized")
 }

--- a/api/api.go
+++ b/api/api.go
@@ -188,7 +188,6 @@ func (api *API) setupRoutes() {
 	ipfsProtected.POST("/calculate-content-hash", api.calculateContentHashForFile)
 	ipfsProtected.GET("/pins", api.getLocalPins) // admin locked
 	ipfsProtected.GET("/object-stat/:key", api.getObjectStatForIpfs)
-	ipfsProtected.GET("/object/size/:key", api.getFileSizeInBytesForObject)
 	ipfsProtected.GET("/check-for-pin/:hash", api.checkLocalNodeForPin) // admin locked
 	ipfsProtected.POST("/download/:hash", api.downloadContentHash)
 	ipfsProtected.POST("/pin/:hash", api.pinHashLocally)
@@ -202,7 +201,6 @@ func (api *API) setupRoutes() {
 	ipfsPrivateProtected.GET("/network/:name", api.getIPFSPrivateNetworkByName)                          // admin locked
 	ipfsPrivateProtected.POST("/ipfs/check-for-pin/:hash", api.checkLocalNodeForPinForHostedIPFSNetwork) // admin locked
 	ipfsPrivateProtected.POST("/ipfs/object-stat/:key", api.getObjectStatForIpfsForHostedIPFSNetwork)
-	ipfsPrivateProtected.POST("/ipfs/object/size/:key", api.getFileSizeInBytesForObjectForHostedIPFSNetwork)
 	ipfsPrivateProtected.POST("/pubsub/publish/:topic", api.ipfsPubSubPublishToHostedIPFSNetwork)
 	ipfsPrivateProtected.POST("/pins", api.getLocalPinsForHostedIPFSNetwork) // admin locked
 	ipfsPrivateProtected.GET("/networks", api.getAuthorizedPrivateNetworks)
@@ -226,7 +224,6 @@ func (api *API) setupRoutes() {
 	clusterProtected.GET("/status-global-pin/:hash", api.getGlobalStatusForClusterPin) // admin locked
 	clusterProtected.GET("/status-local", api.fetchLocalClusterStatus)                 // admin locked
 	clusterProtected.POST("/pin/:hash", api.pinHashToCluster)
-	clusterProtected.DELETE("/remove-pin/:hash", api.removePinFromCluster) // admin locked
 
 	databaseProtected := api.r.Group("/api/v1/database")
 	databaseProtected.Use(authWare.MiddlewareFunc())

--- a/api/context.go
+++ b/api/context.go
@@ -11,7 +11,7 @@ import (
 // Fail fails context with given error and optional status code. Defaults to
 // http.StatusInternalServerError
 func Fail(c *gin.Context, err error, code ...int) {
-	c.JSON(http.StatusBadRequest, gin.H{
+	c.JSON(status(code), gin.H{
 		"code":     status(code),
 		"response": err.Error(),
 	})
@@ -20,7 +20,7 @@ func Fail(c *gin.Context, err error, code ...int) {
 // FailWithMessage fails context with given message and optional status code.
 // Defaults to http.StatusInternalServerError
 func FailWithMessage(c *gin.Context, message string, code ...int) {
-	c.JSON(http.StatusForbidden, gin.H{
+	c.JSON(status(code), gin.H{
 		"code":     status(code),
 		"response": message,
 	})

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -101,29 +101,6 @@ func (api *API) pinHashLocally(c *gin.Context) {
 	Respond(c, http.StatusOK, gin.H{"response": "pin request sent to backend"})
 }
 
-// GetFileSizeInBytesForObject is used to retrieve the size of an object in bytes
-func (api *API) getFileSizeInBytesForObject(c *gin.Context) {
-	username := GetAuthenticatedUserFromContext(c)
-	key := c.Param("key")
-	if _, err := gocid.Decode(key); err != nil {
-		Fail(c, err)
-		return
-	}
-	manager, err := rtfs.Initialize("", "")
-	if err != nil {
-		api.LogError(err, IPFSConnectionError)(c)
-		return
-	}
-	sizeInBytes, err := manager.GetObjectFileSizeInBytes(key)
-	if err != nil {
-		api.LogError(err, IPFSObjectStatError)(c)
-		return
-	}
-
-	api.LogWithUser(username).Info("ipfs object file size requested")
-	Respond(c, http.StatusOK, gin.H{"response": gin.H{"object": key, "size_in_bytes": sizeInBytes}})
-}
-
 // AddFileLocallyAdvanced is used to upload a file in a more resilient
 // and efficient manner than our traditional simple upload. Note that
 // it does not give the user a content hash back immediately

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -97,34 +97,6 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 	Respond(c, http.StatusOK, gin.H{"response": syncedCids})
 }
 
-// RemovePinFromCluster is used to remove a pin from the cluster global state
-// this will mean that all nodes in the cluster will no longer track the pin
-// TODO: use a queue
-func (api *API) removePinFromCluster(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
-		FailNotAuthorized(c, "unauthorized access to cluster removal")
-		return
-	}
-	hash := c.Param("hash")
-	if _, err := gocid.Decode(hash); err != nil {
-		Fail(c, err)
-		return
-	}
-	manager, err := rtfs_cluster.Initialize("", "")
-	if err != nil {
-		api.LogError(err, IPFSClusterConnectionError)(c)
-		return
-	}
-	if err = manager.RemovePinFromCluster(hash); err != nil {
-		api.LogError(err, IPFSClusterPinRemovalError)(c)
-		return
-	}
-
-	api.LogWithUser(ethAddress).Info("pin removal request sent to cluster")
-	Respond(c, http.StatusOK, gin.H{"response": "pin removal request sent to cluster"})
-}
-
 // GetLocalStatusForClusterPin is used to get teh localnode's cluster status for a particular pin
 func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 	ethAddress := GetAuthenticatedUserFromContext(c)

--- a/models/user.go
+++ b/models/user.go
@@ -225,6 +225,7 @@ func (um *UserManager) NewUserAccount(ethAddress, username, password, email stri
 		EmailAddress:      email,
 		AccountEnabled:    true,
 		APIAccess:         true,
+		Credits:           99999999, // this is temporary and will need to be removed before production
 	}
 	if check := um.DB.Create(&user); check.Error != nil {
 		return nil, check.Error


### PR DESCRIPTION
## :construction_worker: Purpose
There was room for some slight optimizations to the API.


## :rocket: Changes
* On sign up, grant user credits. This is temporary for the beta only
* Removed all ability to remove pins through the API
* Removed API routes to get object size, since that is available through object stat
* HTTP Status Codes given on `FailWithMessage` and `Fail` now default as expected

## :warning: Breaking Changes
* Any applications depending on the removed API calls will not work. Luckily this does not effect the Temporal interface as they were unused routes.

