### PR TITLE
Remove Ethereum Addresses From User

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,9 +27,6 @@ import (
 
 var (
 	xssMdlwr xss.XssMw
-
-	// AdminUser is the eth address of the admin account
-	AdminUser = "postables"
 )
 
 // API is our API service
@@ -152,10 +149,8 @@ func (api *API) setupRoutes() {
 	statsProtected.Use(stats.RequestStats())
 	statsProtected.GET("/stats", func(c *gin.Context) { // admin locked
 		username := GetAuthenticatedUserFromContext(c)
-		if username != AdminUser {
-			c.JSON(http.StatusForbidden, gin.H{
-				"error": "unauthorized access",
-			})
+		if err := api.validateAdminRequest(username); err != nil {
+			FailNotAuthorized(c, UnAuthorizedAdminAccess)
 			return
 		}
 		c.JSON(http.StatusOK, stats.Report())

--- a/api/api.go
+++ b/api/api.go
@@ -28,8 +28,8 @@ import (
 var (
 	xssMdlwr xss.XssMw
 
-	// AdminAddress is the eth address of the admin account
-	AdminAddress = "0x7E4A2359c745A982a54653128085eAC69E446DE1"
+	// AdminUser is the eth address of the admin account
+	AdminUser = "postables"
 )
 
 // API is our API service
@@ -151,8 +151,8 @@ func (api *API) setupRoutes() {
 	statsProtected.Use(middleware.APIRestrictionMiddleware(api.dbm.DB))
 	statsProtected.Use(stats.RequestStats())
 	statsProtected.GET("/stats", func(c *gin.Context) { // admin locked
-		ethAddress := GetAuthenticatedUserFromContext(c)
-		if ethAddress != AdminAddress {
+		username := GetAuthenticatedUserFromContext(c)
+		if username != AdminUser {
 			c.JSON(http.StatusForbidden, gin.H{
 				"error": "unauthorized access",
 			})
@@ -230,8 +230,8 @@ func (api *API) setupRoutes() {
 	databaseProtected := api.r.Group("/api/v1/database")
 	databaseProtected.Use(authWare.MiddlewareFunc())
 	databaseProtected.Use(middleware.APIRestrictionMiddleware(api.dbm.DB))
-	databaseProtected.GET("/uploads", api.getUploadsFromDatabase)     // admin locked
-	databaseProtected.GET("/uploads/:user", api.getUploadsForAddress) // partial admin locked
+	databaseProtected.GET("/uploads", api.getUploadsFromDatabase)  // admin locked
+	databaseProtected.GET("/uploads/:user", api.getUploadsForUser) // partial admin locked
 
 	frontendProtected := api.r.Group("/api/v1/frontend/")
 	frontendProtected.Use(authWare.MiddlewareFunc())

--- a/api/api.go
+++ b/api/api.go
@@ -178,7 +178,6 @@ func (api *API) setupRoutes() {
 	accountProtected.POST("password/change", api.changeAccountPassword)
 	accountProtected.GET("/key/ipfs/get", api.getIPFSKeyNamesForAuthUser)
 	accountProtected.POST("/key/ipfs/new", api.createIPFSKey)
-	accountProtected.POST("/ethereum/address/change", api.changeEthereumAddress)
 	accountProtected.GET("/credits/available", api.getCredits)
 
 	ipfsProtected := api.r.Group("/api/v1/ipfs")

--- a/api/errors.go
+++ b/api/errors.go
@@ -85,4 +85,6 @@ const (
 	CallCostCalculationError = "unable to calculate api call cost"
 	// CreditRefundError is an error message used when we are unable to refund a users credits
 	CreditRefundError = "failed to refund credits for user"
+	// UnAuthorizedAdminAccess is an error message used whena user attempts to access an administrative route
+	UnAuthorizedAdminAccess = "user is not an administrator"
 )

--- a/api/errors.go
+++ b/api/errors.go
@@ -53,14 +53,10 @@ const (
 	DNSLinkEntryError = "failed to create dns link entry"
 	// PaymentCreationError is an error used when creating payments
 	PaymentCreationError = "failed to create payment"
-	// EthAddressSearchError is an error used when searching for an eth address
-	EthAddressSearchError = "failed to search for eth address"
 	// PinCostCalculationError is an error message used when calculating pin costs
 	PinCostCalculationError = "failed to calculate pin cost"
 	// PaymentSearchError is an error used when searching for payment
 	PaymentSearchError = "failed to search for payment"
-	// EthAddressChangeError is an error used when changing your eth address
-	EthAddressChangeError = "failed to changing eth address"
 	// DuplicateKeyCreationError is an error used when creating a key of the same name
 	DuplicateKeyCreationError = "key name already exists"
 	// UserAccountCreationError is an error used when creating a user account

--- a/api/middleware/admin.go
+++ b/api/middleware/admin.go
@@ -10,11 +10,11 @@ import (
 )
 
 // AdminRestrictionMiddleware is used to lock down admin protected routes
-func AdminRestrictionMiddleware(db *gorm.DB, adminAdress string) gin.HandlerFunc {
+func AdminRestrictionMiddleware(db *gorm.DB, adminUser string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims := jwt.ExtractClaims(c)
-		ethAddress := claims["id"]
-		if ethAddress != adminAdress {
+		username := claims["id"]
+		if username != adminUser {
 			c.AbortWithError(http.StatusForbidden, errors.New("user is not an admin"))
 			return
 		}

--- a/api/middleware/admin.go
+++ b/api/middleware/admin.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/RTradeLtd/Temporal/models"
 	jwt "github.com/appleboy/gin-jwt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
@@ -13,8 +14,14 @@ import (
 func AdminRestrictionMiddleware(db *gorm.DB, adminUser string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		claims := jwt.ExtractClaims(c)
-		username := claims["id"]
-		if username != adminUser {
+		username := claims["id"].(string)
+		um := models.NewUserManager(db)
+		isAdmin, err := um.CheckIfAdmin(username)
+		if err != nil {
+			c.AbortWithError(http.StatusBadRequest, errors.New("error running middleware"))
+			return
+		}
+		if !isAdmin {
 			c.AbortWithError(http.StatusForbidden, errors.New("user is not an admin"))
 			return
 		}

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -54,8 +54,6 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 
 // RegisterUserAccount is used to sign up with temporal
 func (api *API) registerUserAccount(c *gin.Context) {
-	ethAddress := c.PostForm("eth_address")
-
 	username, exists := c.GetPostForm("username")
 	if !exists {
 		FailWithMissingField(c, "username")
@@ -71,14 +69,11 @@ func (api *API) registerUserAccount(c *gin.Context) {
 		FailWithMissingField(c, "email_address")
 		return
 	}
-	if ethAddress == "" {
-		ethAddress = username
-	}
 	api.l.WithFields(log.Fields{
 		"service": "api",
 	}).Info("user account registration detected")
 
-	userModel, err := api.um.NewUserAccount(ethAddress, username, password, email, false)
+	userModel, err := api.um.NewUserAccount(username, password, email, false)
 	if err != nil {
 		api.LogError(err, UserAccountCreationError)(c)
 		return
@@ -228,23 +223,6 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 	api.LogWithUser(ethAddress).Info("key name list requested")
 
 	Respond(c, http.StatusOK, gin.H{"response": gin.H{"key_names": keys["key_names"], "key_ids": keys["key_ids"]}})
-}
-
-// ChangeEthereumAddress is used to change a user's ethereum address
-func (api *API) changeEthereumAddress(c *gin.Context) {
-	username := GetAuthenticatedUserFromContext(c)
-	ethAddress, exists := c.GetPostForm("eth_address")
-	if !exists {
-		FailWithMissingField(c, "eth_address")
-		return
-	}
-	if _, err := api.um.ChangeEthereumAddress(username, ethAddress); err != nil {
-		api.LogError(err, EthAddressChangeError)(c)
-		return
-	}
-	api.LogWithUser(username).Info("ethereum address changed")
-
-	Respond(c, http.StatusOK, gin.H{"response": "address change successful"})
 }
 
 // GetCredits is used to get a users available credits

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -208,9 +208,9 @@ func (api *API) createIPFSKey(c *gin.Context) {
 
 // GetIPFSKeyNamesForAuthUser is used to get the keys a user has setup
 func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
+	username := GetAuthenticatedUserFromContext(c)
 
-	keys, err := api.um.GetKeysForUser(ethAddress)
+	keys, err := api.um.GetKeysForUser(username)
 	if err != nil {
 		api.LogError(err, KeySearchError)(c)
 		return
@@ -220,7 +220,7 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 		Fail(c, errors.New(NoKeyError), http.StatusNotFound)
 		return
 	}
-	api.LogWithUser(ethAddress).Info("key name list requested")
+	api.LogWithUser(username).Info("key name list requested")
 
 	Respond(c, http.StatusOK, gin.H{"response": gin.H{"key_names": keys["key_names"], "key_ids": keys["key_ids"]}})
 }

--- a/api/routes_database.go
+++ b/api/routes_database.go
@@ -12,8 +12,8 @@ var dev = false
 // GetUploadsFromDatabase is used to read a list of uploads from our database
 func (api *API) getUploadsFromDatabase(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	um := models.NewUploadManager(api.dbm.DB)
@@ -33,7 +33,8 @@ func (api *API) getUploadsForUser(c *gin.Context) {
 	var queryUser string
 	um := models.NewUploadManager(api.dbm.DB)
 	username := GetAuthenticatedUserFromContext(c)
-	if username == AdminUser {
+	err := api.validateAdminRequest(username)
+	if err == nil {
 		queryUser = c.Param("user")
 	} else {
 		queryUser = username

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -129,7 +129,7 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 // GenerateDNSLinkEntry is used to generate a DNS link entry
 func (api *API) generateDNSLinkEntry(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminAddress {
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}

--- a/api/routes_ipns.go
+++ b/api/routes_ipns.go
@@ -129,8 +129,8 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 // GenerateDNSLinkEntry is used to generate a DNS link entry
 func (api *API) generateDNSLinkEntry(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	recordName, exists := c.GetPostForm("record_name")

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -11,8 +11,8 @@ import (
 // MakeBucket is used to create a bucket in our minio container
 func (api *API) makeBucket(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	bucketName, exists := c.GetPostForm("bucket_name")

--- a/api/routes_mini.go
+++ b/api/routes_mini.go
@@ -10,8 +10,8 @@ import (
 
 // MakeBucket is used to create a bucket in our minio container
 func (api *API) makeBucket(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access")
 		return
 	}
@@ -39,7 +39,7 @@ func (api *API) makeBucket(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("minio bucket created")
+	api.LogWithUser(username).Info("minio bucket created")
 
 	Respond(c, http.StatusOK, gin.H{"response": "bucket created"})
 }

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -349,8 +349,8 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 // This is admin locked to avoid peformance penalties from looking up the pinset
 func (api *API) getLocalPins(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	// initialize a connection toe the local ipfs node
@@ -399,8 +399,8 @@ func (api *API) getObjectStatForIpfs(c *gin.Context) {
 // CheckLocalNodeForPin is used to check whether or not the serving node is tacking the particular pin
 func (api *API) checkLocalNodeForPin(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	hash := c.Param("hash")

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -348,8 +348,8 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 // GetLocalPins is used to get the pins tracked by the serving ipfs node
 // This is admin locked to avoid peformance penalties from looking up the pinset
 func (api *API) getLocalPins(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -367,7 +367,7 @@ func (api *API) getLocalPins(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("ipfs pin list requested")
+	api.LogWithUser(username).Info("ipfs pin list requested")
 	Respond(c, http.StatusOK, gin.H{"response": pinInfo})
 }
 
@@ -398,8 +398,8 @@ func (api *API) getObjectStatForIpfs(c *gin.Context) {
 
 // CheckLocalNodeForPin is used to check whether or not the serving node is tacking the particular pin
 func (api *API) checkLocalNodeForPin(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -419,7 +419,7 @@ func (api *API) checkLocalNodeForPin(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("ipfs pin check requested")
+	api.LogWithUser(username).Info("ipfs pin check requested")
 
 	Respond(c, http.StatusOK, gin.H{"response": present})
 }

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -76,8 +76,8 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 // SyncClusterErrorsLocally is used to parse through the local cluster state and sync any errors that are detected.
 func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	// initialize a conection to the cluster
@@ -102,8 +102,8 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 // TODO: use a queue
 func (api *API) removePinFromCluster(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to cluster removal")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	hash := c.Param("hash")
@@ -128,8 +128,8 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 // GetLocalStatusForClusterPin is used to get teh localnode's cluster status for a particular pin
 func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	hash := c.Param("hash")
@@ -158,8 +158,8 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 // GetGlobalStatusForClusterPin is used to get the global cluster status for a particular pin
 func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to cluster status")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	hash := c.Param("hash")
@@ -188,8 +188,8 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 // FetchLocalClusterStatus is used to fetch the status of the localhost's cluster state, and not the rest of the cluster
 func (api *API) fetchLocalClusterStatus(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	// this will hold all the retrieved content hashes

--- a/api/routes_rtfs_cluster.go
+++ b/api/routes_rtfs_cluster.go
@@ -75,8 +75,8 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 
 // SyncClusterErrorsLocally is used to parse through the local cluster state and sync any errors that are detected.
 func (api *API) syncClusterErrorsLocally(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -93,7 +93,7 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("local cluster errors parsed")
+	api.LogWithUser(username).Info("local cluster errors parsed")
 	Respond(c, http.StatusOK, gin.H{"response": syncedCids})
 }
 
@@ -101,8 +101,8 @@ func (api *API) syncClusterErrorsLocally(c *gin.Context) {
 // this will mean that all nodes in the cluster will no longer track the pin
 // TODO: use a queue
 func (api *API) removePinFromCluster(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to cluster removal")
 		return
 	}
@@ -121,14 +121,14 @@ func (api *API) removePinFromCluster(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("pin removal request sent to cluster")
+	api.LogWithUser(username).Info("pin removal request sent to cluster")
 	Respond(c, http.StatusOK, gin.H{"response": "pin removal request sent to cluster"})
 }
 
 // GetLocalStatusForClusterPin is used to get teh localnode's cluster status for a particular pin
 func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -150,15 +150,15 @@ func (api *API) getLocalStatusForClusterPin(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("local cluster status for pin requested")
+	api.LogWithUser(username).Info("local cluster status for pin requested")
 
 	Respond(c, http.StatusOK, gin.H{"response": status})
 }
 
 // GetGlobalStatusForClusterPin is used to get the global cluster status for a particular pin
 func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to cluster status")
 		return
 	}
@@ -180,15 +180,15 @@ func (api *API) getGlobalStatusForClusterPin(c *gin.Context) {
 		return
 	}
 
-	api.LogWithUser(ethAddress).Info("global cluster status for pin requested")
+	api.LogWithUser(username).Info("global cluster status for pin requested")
 
 	Respond(c, http.StatusOK, gin.H{"response": status})
 }
 
 // FetchLocalClusterStatus is used to fetch the status of the localhost's cluster state, and not the rest of the cluster
 func (api *API) fetchLocalClusterStatus(c *gin.Context) {
-	ethAddress := GetAuthenticatedUserFromContext(c)
-	if ethAddress != AdminAddress {
+	username := GetAuthenticatedUserFromContext(c)
+	if username != AdminUser {
 		FailNotAuthorized(c, "unauthorized access to admin route")
 		return
 	}
@@ -214,6 +214,6 @@ func (api *API) fetchLocalClusterStatus(c *gin.Context) {
 		statuses = append(statuses, v)
 	}
 
-	api.LogWithUser(ethAddress).Info("local cluster state fetched")
+	api.LogWithUser(username).Info("local cluster state fetched")
 	Respond(c, http.StatusOK, gin.H{"response": gin.H{"cids": cids, "statuses": statuses}})
 }

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -408,8 +408,8 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 // GetLocalPinsForHostedIPFSNetwork is used to get local pins from the serving private ipfs node
 func (api *API) getLocalPinsForHostedIPFSNetwork(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -487,8 +487,8 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 // CheckLocalNodeForPinForHostedIPFSNetwork is used to check the serving node for a pin
 func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access to admin route")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -642,11 +642,10 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 	// lock down as admin route for now
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
-
 	networkName, exists := c.GetPostForm("network_name")
 	if !exists {
 		FailWithBadRequest(c, "network_name")
@@ -756,11 +755,10 @@ func (api *API) createHostedIPFSNetworkEntryInDatabase(c *gin.Context) {
 // GetIPFSPrivateNetworkByName is used to get connection information for a priavate ipfs network
 func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
-	if username != AdminUser {
-		FailNotAuthorized(c, "unauthorized access")
+	if err := api.validateAdminRequest(username); err != nil {
+		FailNotAuthorized(c, UnAuthorizedAdminAccess)
 		return
 	}
-
 	netName := c.Param("name")
 	manager := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	net, err := manager.GetNetworkByName(netName)

--- a/api/utils.go
+++ b/api/utils.go
@@ -35,9 +35,9 @@ func CalculateFileSize(c *gin.Context) {
 }
 
 // CheckAccessForPrivateNetwork checks if a user has access to a private network
-func CheckAccessForPrivateNetwork(ethAddress, networkName string, db *gorm.DB) error {
+func CheckAccessForPrivateNetwork(username, networkName string, db *gorm.DB) error {
 	um := models.NewUserManager(db)
-	canUpload, err := um.CheckIfUserHasAccessToNetwork(ethAddress, networkName)
+	canUpload, err := um.CheckIfUserHasAccessToNetwork(username, networkName)
 	if err != nil {
 		return err
 	}

--- a/api/utils.go
+++ b/api/utils.go
@@ -115,3 +115,15 @@ func (api *API) refundUserCredits(username, callType string, cost float64) {
 		}).Error(CreditRefundError)
 	}
 }
+
+// validateAdminRequest is used to validate whether or not the requesting user is an administrator
+func (api *API) validateAdminRequest(username string) error {
+	isAdmin, err := api.um.CheckIfAdmin(username)
+	if err != nil {
+		return err
+	}
+	if !isAdmin {
+		return errors.New(UnAuthorizedAdminAccess)
+	}
+	return nil
+}

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -79,7 +79,3 @@ func (mm *MailManager) SendEmail(subject, content, contentType, recipientName, r
 	}
 	return response.StatusCode, nil
 }
-
-type Message struct {
-	EthAddress string `json:"eth_address"`
-}

--- a/models/user.go
+++ b/models/user.go
@@ -13,7 +13,6 @@ import (
 // User is our user model for anyone who signs up with Temporal
 type User struct {
 	gorm.Model
-	EthAddress        string  `gorm:"type:varchar(255);unique"`
 	UserName          string  `gorm:"type:varchar(255);unique"`
 	EmailAddress      string  `gorm:"type:varchar(255);unique"`
 	EnterpriseEnabled bool    `gorm:"type:boolean"`
@@ -201,7 +200,7 @@ func (um *UserManager) ChangePassword(username, currentPassword, newPassword str
 }
 
 // NewUserAccount is used to create a new user account
-func (um *UserManager) NewUserAccount(ethAddress, username, password, email string, enterpriseEnabled bool) (*User, error) {
+func (um *UserManager) NewUserAccount(username, password, email string, enterpriseEnabled bool) (*User, error) {
 	user := User{}
 	check := um.DB.Where("user_name = ?", username).First(&user)
 	if check.Error != nil && check.Error != gorm.ErrRecordNotFound {
@@ -214,12 +213,8 @@ func (um *UserManager) NewUserAccount(ethAddress, username, password, email stri
 	if err != nil {
 		return nil, err
 	}
-	if ethAddress == "" {
-		ethAddress = username
-	}
 	user = User{
 		UserName:          username,
-		EthAddress:        ethAddress,
 		EnterpriseEnabled: enterpriseEnabled,
 		HashedPassword:    hex.EncodeToString(hashedPass),
 		EmailAddress:      email,
@@ -290,15 +285,6 @@ func (um *UserManager) FindByUserName(username string) (*User, error) {
 	return &u, nil
 }
 
-// FindEthAddressByUserName is used to retrieve a users eth address by searching for their username
-func (um *UserManager) FindEthAddressByUserName(username string) (string, error) {
-	u := User{}
-	if check := um.DB.Where("user_name = ?", username).First(&u); check.Error != nil {
-		return "", check.Error
-	}
-	return u.EthAddress, nil
-}
-
 // FindEmailByUserName is used to find an email address by searching for the users eth address
 // the returned map contains their eth address as a key, and their email address as a value
 func (um *UserManager) FindEmailByUserName(username string) (map[string]string, error) {
@@ -310,19 +296,6 @@ func (um *UserManager) FindEmailByUserName(username string) (map[string]string, 
 	emails := make(map[string]string)
 	emails[username] = u.EmailAddress
 	return emails, nil
-}
-
-// ChangeEthereumAddress is used to change a user's ethereum address
-func (um *UserManager) ChangeEthereumAddress(username, ethAddress string) (*User, error) {
-	u := User{}
-	if check := um.DB.Where("user_name = ?", username).First(&u); check.Error != nil {
-		return nil, check.Error
-	}
-	u.EthAddress = ethAddress
-	if check := um.DB.Model(u).Update("eth_address", ethAddress); check.Error != nil {
-		return nil, check.Error
-	}
-	return &u, nil
 }
 
 // AddCredits is used to add credits to a user account

--- a/models/user.go
+++ b/models/user.go
@@ -19,6 +19,7 @@ type User struct {
 	AccountEnabled    bool    `gorm:"type:boolean"`
 	APIAccess         bool    `gorm:"type:boolean"`
 	EmailEnabled      bool    `gorm:"type:boolean"`
+	AdminAccess       bool    `gorm:"type:boolean"`
 	HashedPassword    string  `gorm:"type:varchar(255)"`
 	Credits           float64 `gorm:"type:float;default:0"`
 	// IPFSKeyNames is an array of IPFS keys this user has created
@@ -220,6 +221,7 @@ func (um *UserManager) NewUserAccount(username, password, email string, enterpri
 		EmailAddress:      email,
 		AccountEnabled:    true,
 		APIAccess:         true,
+		AdminAccess:       false,
 	}
 	if check := um.DB.Create(&user); check.Error != nil {
 		return nil, check.Error
@@ -324,4 +326,13 @@ func (um *UserManager) RemoveCredits(username string, credits float64) (*User, e
 		return nil, check.Error
 	}
 	return user, nil
+}
+
+// CheckIfAdmin is used to check if an account is an administrator
+func (um *UserManager) CheckIfAdmin(username string) (bool, error) {
+	user, err := um.FindByUserName(username)
+	if err != nil {
+		return false, err
+	}
+	return user.AdminAccess, nil
 }

--- a/models/user.go
+++ b/models/user.go
@@ -266,16 +266,6 @@ func (um *UserManager) ComparePlaintextPasswordToHash(username, password string)
 
 }
 
-// FindByAddress is used to find a user account by their address
-func (um *UserManager) FindByAddress(address string) *User {
-	u := User{}
-	um.DB.Where("eth_address = ?", address).Find(&u)
-	if u.CreatedAt == nilTime {
-		return nil
-	}
-	return &u
-}
-
 // FindByUserName is used to find a user by their username
 func (um *UserManager) FindByUserName(username string) (*User, error) {
 	u := User{}

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -15,51 +15,10 @@ var (
 )
 
 type args struct {
-	ethAddress        string
 	userName          string
 	email             string
 	password          string
 	enterpriseEnabled bool
-}
-
-func TestUserManager_ChangeEthereumAddress(t *testing.T) {
-	cfg, err := config.LoadConfig(testCfgPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	db, err := openDatabaseConnection(t, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	um := models.NewUserManager(db)
-
-	var (
-		randUtils  = utils.GenerateRandomUtils()
-		username   = randUtils.GenerateString(10, utils.LetterBytes)
-		ethAddress = randUtils.GenerateString(10, utils.LetterBytes)
-		email      = randUtils.GenerateString(10, utils.LetterBytes)
-	)
-
-	tests := []struct {
-		name string
-		args args
-	}{
-		{"ChangeEthereumAddress", args{ethAddress, username, email, "password123", false}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer um.DB.Delete(user)
-			if _, err := um.ChangeEthereumAddress(tt.args.userName, tt.args.ethAddress); err != nil {
-				t.Error(err)
-			}
-		})
-	}
 }
 
 func TestUserManager_ChangePassword(t *testing.T) {
@@ -75,21 +34,20 @@ func TestUserManager_ChangePassword(t *testing.T) {
 	um := models.NewUserManager(db)
 
 	var (
-		randUtils  = utils.GenerateRandomUtils()
-		username   = randUtils.GenerateString(10, utils.LetterBytes)
-		ethAddress = randUtils.GenerateString(10, utils.LetterBytes)
-		email      = randUtils.GenerateString(10, utils.LetterBytes)
+		randUtils = utils.GenerateRandomUtils()
+		username  = randUtils.GenerateString(10, utils.LetterBytes)
+		email     = randUtils.GenerateString(10, utils.LetterBytes)
 	)
 
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"ChangePassword", args{ethAddress, username, email, "password123", false}},
+		{"ChangePassword", args{username, email, "password123", false}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			user, err := um.NewUserAccount(tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -118,22 +76,21 @@ func TestUserManager_NewAccount(t *testing.T) {
 	um := models.NewUserManager(db)
 
 	var (
-		randUtils  = utils.GenerateRandomUtils()
-		username   = randUtils.GenerateString(10, utils.LetterBytes)
-		ethAddress = randUtils.GenerateString(10, utils.LetterBytes)
-		email      = randUtils.GenerateString(10, utils.LetterBytes)
+		randUtils = utils.GenerateRandomUtils()
+		username  = randUtils.GenerateString(10, utils.LetterBytes)
+		email     = randUtils.GenerateString(10, utils.LetterBytes)
 	)
 
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"AccountCreation", args{ethAddress, username, email, "password123", false}},
+		{"AccountCreation", args{username, email, "password123", false}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			user, err := um.NewUserAccount(tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -155,22 +112,21 @@ func TestUserManager_SignIn(t *testing.T) {
 	um := models.NewUserManager(db)
 
 	var (
-		randUtils  = utils.GenerateRandomUtils()
-		username   = randUtils.GenerateString(10, utils.LetterBytes)
-		ethAddress = randUtils.GenerateString(10, utils.LetterBytes)
-		email      = randUtils.GenerateString(10, utils.LetterBytes)
+		randUtils = utils.GenerateRandomUtils()
+		username  = randUtils.GenerateString(10, utils.LetterBytes)
+		email     = randUtils.GenerateString(10, utils.LetterBytes)
 	)
 
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"AccountCreation", args{ethAddress, username, email, "password123", false}},
+		{"AccountCreation", args{username, email, "password123", false}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			user, err := um.NewUserAccount(tt.args.ethAddress, tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
+			user, err := um.NewUserAccount(tt.args.userName, tt.args.password, tt.args.email, tt.args.enterpriseEnabled)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	testCID           = "QmPY5iMFjNZKxRbUZZC85wXb9CFgNSyzAy1LxwL62D8VGr"
-	testEthAddress    = "0x7E4A2359c745A982a54653128085eAC69E446DE1"
 	testRabbitAddress = "amqp://127.0.0.1:5672"
 )
 


### PR DESCRIPTION
## :construction_worker: Purpose
Ethereum addresses as they were  implemented had been deprecated.


## :rocket: Changes
* All references to ethereum addresses on a per-user basis have been removed.
* Hard coded `AdminUser` is now gone
* User model has an `AdminAccess` boolean value

## :warning: Breaking Changes
* Yes, databases will need to be migrated using our migration command.
