### PR TITLE
Change Default RTFS Time Out

### DIFF
--- a/rtfs/rtfs.go
+++ b/rtfs/rtfs.go
@@ -29,7 +29,7 @@ func Initialize(pubTopic, connectionURL string) (*IpfsManager, error) {
 		PubTopic:    pubTopic,
 		nodeAPIAddr: connectionURL,
 	}
-	manager.SetTimeout(time.Minute * 1)
+	manager.SetTimeout(time.Minute * 10)
 	_, err := manager.Shell.ID()
 	return &manager, err
 }


### PR DESCRIPTION
## :construction_worker: Purpose
Default time-out was causing occasional IPNS record creation failures


## :rocket: Changes
Change default time out from 1 min to 10 min


## :warning: Breaking Changes
None

