### PR TITLE
Check For Queued Pins

### DIFF
--- a/setup/scripts/ipfs_cluster_monitor.sh
+++ b/setup/scripts/ipfs_cluster_monitor.sh
@@ -13,6 +13,9 @@ case "$1" in
             exit 0
         fi
         ;;
+    queued-pin-count)
+        echo ipfs-cluster-ctl status | grep PIN_QUEUED | wc -l
+        ;;
     pin-count)
         COUNT=$(ipfs-cluster-ctl pin ls | wc -l)
         echo "$COUNT"


### PR DESCRIPTION
## :construction_worker: Purpose
Add command to check the number of queued pins.
Useful when bootstrapping a new node

## :rocket: Changes
New command in `ipfs_cluster_monitor.sh`


## :warning: Breaking Changes
None

