### PR TITLE
Email Refactor + Queue Log Cleanup, TEM-57 + TEM-101

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_script:
   - go build ./...
   - go test -run xxxx ./...
   - make testenv
-  - mkdir /var/log/temporal
 
 script:
   # - docker run -v $(pwd):/mnt koalaman/shellcheck **/*.sh(e[' [[ ! `echo "$REPLY" | grep "vendor/" ` ]]'])

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - go build ./...
   - go test -run xxxx ./...
   - make testenv
+  - mkdir /var/log/temporal
 
 script:
   # - docker run -v $(pwd):/mnt koalaman/shellcheck **/*.sh(e[' [[ ! `echo "$REPLY" | grep "vendor/" ` ]]'])

--- a/api/api.go
+++ b/api/api.go
@@ -209,6 +209,14 @@ func (api *API) setupRoutes() {
 		{
 			credits.GET("/available", api.getCredits)
 		}
+		email := account.Group("/email")
+		{
+			token := email.Group("/token")
+			{
+				token.GET("/get", api.getEmailVerificationToken)
+				token.POST("/verify", api.verifyEmailAddress)
+			}
+		}
 	}
 
 	// ipfs

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-
 // verifyEmailAddress is used to verify a users email address
 func (api *API) verifyEmailAddress(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
@@ -55,6 +54,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "Email verification token sent to email. Please check and follow instructions"})
+}
 
 // registerAirDrop is used to register an airdrop
 func (api *API) registerAirDrop(c *gin.Context) {

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -13,6 +13,48 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// verifyEmailAddress is used to verify a users email address
+func (api *API) verifyEmailAddress(c *gin.Context) {
+	username := GetAuthenticatedUserFromContext(c)
+	token, exists := c.GetPostForm("token")
+	if !exists {
+		FailWithMissingField(c, "token")
+		return
+	}
+	if _, err := api.um.ValidateEmailVerificationToken(username, token); err != nil {
+		api.LogError(err, eh.EmailVerificationError)(c, http.StatusBadRequest)
+		return
+	}
+	Respond(c, http.StatusOK, gin.H{"response": "email verified"})
+}
+
+// getEmailVerificationToken is used to generate a token which can be used to validate an email address
+func (api *API) getEmailVerificationToken(c *gin.Context) {
+	username := GetAuthenticatedUserFromContext(c)
+	user, err := api.um.GenerateEmailVerificationToken(username)
+	if err != nil {
+		api.LogError(err, eh.EmailTokenGenerationError)(c, http.StatusBadRequest)
+		return
+	}
+	es := queue.EmailSend{
+		Subject:     "TEMPORAL Email Verification",
+		Content:     fmt.Sprintf("Please submit the following email verification token: %s\n", user.EmailVerificationToken),
+		ContentType: "text/html",
+		UserNames:   []string{user.UserName},
+	}
+	mqURL := api.cfg.RabbitMQ.URL
+	qm, err := queue.Initialize(queue.EmailSendQueue, mqURL, true, false)
+	if err != nil {
+		api.LogError(err, eh.QueueInitializationError)(c, http.StatusBadRequest)
+		return
+	}
+	if err = qm.PublishMessage(es); err != nil {
+		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		return
+	}
+	Respond(c, http.StatusOK, gin.H{"response": "Email verification token sent to email. Please check and follow instructions"})
+}
+
 // ChangeAccountPassword is used to change a users password
 func (api *API) changeAccountPassword(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)

--- a/api/routes_account.go
+++ b/api/routes_account.go
@@ -41,6 +41,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 		Content:     fmt.Sprintf("Please submit the following email verification token: %s\n", user.EmailVerificationToken),
 		ContentType: "text/html",
 		UserNames:   []string{user.UserName},
+		Emails:      []string{user.EmailAddress},
 	}
 	mqURL := api.cfg.RabbitMQ.URL
 	qm, err := queue.Initialize(queue.EmailSendQueue, mqURL, true, false)

--- a/eh/errors.go
+++ b/eh/errors.go
@@ -93,4 +93,8 @@ const (
 	DuplicateEmailError = "email address already taken"
 	// DuplicateUserNameError is an error used whe na user attempts to register with an already taken user name
 	DuplicateUserNameError = "username is already taken"
+	// EmailVerificationError is an error used when a user fails to validate their email address
+	EmailVerificationError = "failed to verify email address"
+	// EmailTokenGenerationError is an error messaged used when failing to generate a token
+	EmailTokenGenerationError = "failed to generate email verification token"
 )

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -36,7 +36,7 @@ func GenerateMailManager(tCfg *config.TemporalConfig) (*Manager, error) {
 		port = tCfg.Database.Port
 	}
 	db, err := database.OpenDBConnection(database.DBOptions{
-		User: dbUser, Password: dbPass, Address: dbURL, Port: port, SSLModeDisable: true})
+		User: dbUser, Password: dbPass, Address: dbURL, Port: port})
 	if err != nil {
 		return nil, err
 	}

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -19,8 +19,8 @@ type Manager struct {
 	UserManager  *models.UserManager `json:"user_manager"`
 }
 
-// GenerateMailManager is used to generate our mail manager service
-func GenerateMailManager(tCfg *config.TemporalConfig) (*Manager, error) {
+// NewManager is used to create our mail manager, allowing us to send email
+func NewManager(tCfg *config.TemporalConfig) (*Manager, error) {
 	apiKey := tCfg.Sendgrid.APIKey
 	emailAddress := tCfg.Sendgrid.EmailAddress
 	emailName := tCfg.Sendgrid.EmailName

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	recipient = "insertemailhere"
+	recipient = "alext@rtradetechnologies.com"
 	cfgPath   = filepath.Join(os.Getenv("HOME"), "config.json")
 )
 

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -24,7 +24,7 @@ func TestMail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mm, err := mail.GenerateMailManager(cfg)
+	mm, err := mail.NewManager(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -33,33 +33,19 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 		return err
 	}
 	userManager := models.NewUserManager(db)
-
-	qm.Logger.WithFields(log.Fields{
-		"service": qm.QueueName,
-	}).Info("processing ipfs key creation requests")
-
+	qm.LogInfo("processing ipfs key creation requests")
 	for d := range msgs {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("new message detected")
-
+		qm.LogInfo("new message detected")
 		key := IPFSKeyCreation{}
 		err = json.Unmarshal(d.Body, &key)
 		if err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"error":   err.Error(),
-			}).Error("failed to unmarshal message")
+			qm.LogError(err, "failed to unmarshal message")
 			d.Ack(false)
 			continue
 		}
 		if key.NetworkName != "public" {
 			qm.refundCredits(key.UserName, "key", key.CreditCost, db)
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    key.UserName,
-				"error":   errors.New("private network key creation not yet supported"),
-			}).Error("private network key creation not yet supported")
+			qm.LogError(err, "private network key creation not yet supported")
 			d.Ack(false)
 			continue
 		}
@@ -70,11 +56,7 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 			keyTypeInt = ci.RSA
 			if key.Size > 4096 {
 				qm.refundCredits(key.UserName, "key", key.CreditCost, db)
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    key.UserName,
-					"error":   "key size error",
-				}).Error("rsa key generation larger than 4096 bits not supported")
+				qm.LogError(err, "rsa key generation larger than 4096 bits not supported")
 				d.Ack(false)
 				continue
 			}
@@ -84,11 +66,7 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 			bitsInt = 256
 		default:
 			qm.refundCredits(key.UserName, "key", key.CreditCost, db)
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    key.UserName,
-				"error":   "unsupported key type",
-			}).Errorf("%s is not a valid key type, only ed25519 and rsa are supported", key.Type)
+			qm.LogError(err, "invalid key type must be ed25519 or rsa")
 			d.Ack(false)
 			continue
 		}
@@ -96,11 +74,7 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 		pk, err := manager.KeystoreManager.CreateAndSaveKey(keyName, keyTypeInt, bitsInt)
 		if err != nil {
 			qm.refundCredits(key.UserName, "key", key.CreditCost, db)
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    key.UserName,
-				"error":   err.Error(),
-			}).Error("failed to create and save key")
+			qm.LogError(err, "failed to create and save key")
 			d.Ack(false)
 			continue
 		}
@@ -108,28 +82,17 @@ func (qm *QueueManager) ProcessIPFSKeyCreation(msgs <-chan amqp.Delivery, db *go
 		id, err := peer.IDFromPrivateKey(pk)
 		if err != nil {
 			qm.refundCredits(key.UserName, "key", key.CreditCost, db)
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    key.UserName,
-				"error":   err.Error(),
-			}).Error("failed to get id from private key")
+			qm.LogError(err, "failed to get id from private key")
 			d.Ack(false)
 			continue
 		}
 		// doesn't need a refund, key wasgenerated, but information not saved to db
 		if err := userManager.AddIPFSKeyForUser(key.UserName, keyName, id.Pretty()); err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    key.UserName,
-				"error":   err.Error(),
-			}).Error("failed to add ipfs key to database")
+			qm.LogError(err, "failed to add ipfs key to database")
 			d.Ack(false)
 			continue
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    key.UserName,
-		}).Info("successfully processed ipfs key creation")
+		qm.LogInfo("successfully processed ipfs key creation request")
 		d.Ack(false)
 	}
 	return nil
@@ -141,39 +104,18 @@ func (qm *QueueManager) ProccessIPFSPins(msgs <-chan amqp.Delivery, db *gorm.DB,
 	//uploadManager := models.NewUploadManager(db)
 	networkManager := models.NewHostedIPFSNetworkManager(db)
 	uploadManager := models.NewUploadManager(db)
-	qmEmail, err := Initialize(EmailSendQueue, cfg.RabbitMQ.URL, true, false)
-	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to initialize email queue connection")
-		return err
-	}
 	qmCluster, err := Initialize(IpfsClusterPinQueue, cfg.RabbitMQ.URL, true, false)
 	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to initialize cluster pin queue connection")
+		qm.LogError(err, "failed to initialize cluster pin queue connection")
 		return err
 	}
-
-	qm.Logger.WithFields(log.Fields{
-		"service": qm.QueueName,
-	}).Info("processing ipfs pins")
-
+	qm.LogInfo("processing ipfs pins")
 	for d := range msgs {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("new message detected")
-
+		qm.LogInfo("new message detected")
 		pin := &IPFSPin{}
 		err := json.Unmarshal(d.Body, pin)
 		if err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"error":   err.Error(),
-			}).Error("failed to unmarshal message")
+			qm.LogError(err, "failed to unmarshal message")
 			d.Ack(false)
 			continue
 		}
@@ -182,148 +124,57 @@ func (qm *QueueManager) ProccessIPFSPins(msgs <-chan amqp.Delivery, db *gorm.DB,
 			canAccess, err := userManager.CheckIfUserHasAccessToNetwork(pin.UserName, pin.NetworkName)
 			if err != nil {
 				qm.refundCredits(pin.UserName, "pin", pin.CreditCost, db)
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    pin.UserName,
-					"error":   err.Error(),
-				}).Error("error looking up private network in database")
+				qm.LogError(err, "failed to lookup private network in database")
 				d.Ack(false)
 				continue
 			}
 			if !canAccess {
 				qm.refundCredits(pin.UserName, "pin", pin.CreditCost, db)
-				usernames := []string{}
-				usernames = append(usernames, pin.UserName)
-				es := EmailSend{
-					Subject:     IpfsPrivateNetworkUnauthorizedSubject,
-					Content:     fmt.Sprintf("Unauthorized access to IPFS private network %s", pin.NetworkName),
-					ContentType: "",
-					UserNames:   usernames,
-				}
-				err = qmEmail.PublishMessage(es)
-				if err != nil {
-					qm.Logger.WithFields(log.Fields{
-						"service": qm.QueueName,
-						"error":   err.Error(),
-					}).Error("failed to publish email send to queue")
-				}
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    pin.UserName,
-				}).Warn("user does not have access to private network")
+				qm.LogError(errors.New("user does not have access to private network"), "invalid private network access")
 				d.Ack(false)
 				continue
 			}
 			url, err := networkManager.GetAPIURLByName(pin.NetworkName)
 			if err != nil {
 				qm.refundCredits(pin.UserName, "pin", pin.CreditCost, db)
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    pin.UserName,
-					"error":   err.Error(),
-				}).Error("failed to lookup api url by name in database")
+				qm.LogError(err, "failed to search for api url")
 				d.Ack(false)
 				continue
 			}
 			apiURL = url
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    pin.UserName,
-		}).Info("initializing connection to IPFS")
+		qm.LogInfo("initializing connection to ipfs")
 		ipfsManager, err := rtfs.Initialize("", apiURL)
 		if err != nil {
 			qm.refundCredits(pin.UserName, "pin", pin.CreditCost, db)
-			addresses := []string{}
-			addresses = append(addresses, pin.UserName)
-			es := EmailSend{
-				Subject:     IpfsInitializationFailedSubject,
-				Content:     fmt.Sprintf("Connection to IPFS failed due to the following error %s", err),
-				ContentType: "",
-				UserNames:   addresses,
-			}
-			errOne := qmEmail.PublishMessage(es)
-			if errOne != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"error":   err.Error(),
-				}).Error("failed to publish email send to queue")
-			}
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    pin.UserName,
-				"error":   err.Error(),
-			}).Error("failed to initialize connection to IPFS")
+			qm.LogError(err, "failed to initialize connection to ipfs")
 			d.Ack(false)
 			continue
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    pin.UserName,
-			"network": pin.NetworkName,
-		}).Infof("pinning %s to ipfs", pin.CID)
-		err = ipfsManager.Pin(pin.CID)
-		if err != nil {
+		qm.LogInfo("pinning hash to ipfs")
+		if err = ipfsManager.Pin(pin.CID); err != nil {
 			qm.refundCredits(pin.UserName, "pin", pin.CreditCost, db)
-			addresses := []string{}
-			addresses = append(addresses, pin.UserName)
-			es := EmailSend{
-				Subject:     IpfsPinFailedSubject,
-				Content:     fmt.Sprintf(IpfsPinFailedContent, pin.CID, pin.NetworkName, err),
-				ContentType: "",
-				UserNames:   addresses,
-			}
-			errOne := qmEmail.PublishMessage(es)
-			if errOne != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"error":   err.Error(),
-				}).Error("failed to publish email send to queue")
-			}
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    pin.UserName,
-				"network": pin.NetworkName,
-				"error":   err.Error(),
-			}).Errorf("failed to pin %s to ipfs", pin.CID)
+			qm.LogError(err, "failed to pin hash to ipfs")
 			d.Ack(false)
 			continue
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    pin.UserName,
-			"network": pin.NetworkName,
-		}).Infof("successfully pinned %s to ipfs", pin.CID)
+		qm.LogInfo("successfully pinned hash to ipfs")
 		clusterAddMsg := IPFSClusterPin{
 			CID:              pin.CID,
 			NetworkName:      pin.NetworkName,
 			HoldTimeInMonths: pin.HoldTimeInMonths,
 			UserName:         pin.UserName,
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    pin.UserName,
-			"network": pin.NetworkName,
-		}).Infof("publishing cluster pin request for %s", pin.CID)
 		// no need to do any payment processing on cluster as it has been handled already
 		clusterAddMsg.CreditCost = 0
-		err = qmCluster.PublishMessage(clusterAddMsg)
-		// doesn't need a reunfd as item is pinned to local IPFS nodes.
-		if err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    pin.UserName,
-				"network": pin.NetworkName,
-			}).Errorf("failed to publish cluster pin request for %s", pin.CID)
+		if err = qmCluster.PublishMessage(clusterAddMsg); err != nil {
+			qm.LogError(err, "failed to publish cluster pin message to rabbitmq")
+			d.Ack(false)
+			continue
 		}
 		_, err = uploadManager.FindUploadByHashAndNetwork(pin.CID, pin.NetworkName)
 		if err != nil && err != gorm.ErrRecordNotFound {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    pin.UserName,
-				"network": pin.NetworkName,
-				"error":   err.Error(),
-			}).Error("failed to find model from database")
+			qm.LogError(err, "failed to find upload in database")
 			d.Ack(false)
 			continue
 		}
@@ -333,12 +184,7 @@ func (qm *QueueManager) ProccessIPFSPins(msgs <-chan amqp.Delivery, db *gorm.DB,
 				Username:         pin.UserName,
 				HoldTimeInMonths: pin.HoldTimeInMonths})
 			if err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    pin.UserName,
-					"network": pin.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to create upload in database")
+				qm.LogError(err, "failed to create upload in database")
 				d.Ack(false)
 				continue
 			}
@@ -346,21 +192,12 @@ func (qm *QueueManager) ProccessIPFSPins(msgs <-chan amqp.Delivery, db *gorm.DB,
 			// the record already exists so we will update
 			_, err = uploadManager.UpdateUpload(pin.HoldTimeInMonths, pin.UserName, pin.CID, pin.NetworkName)
 			if err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    pin.UserName,
-					"network": pin.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to update upload in database")
+				qm.LogError(err, "failed to update upload in database")
 				d.Ack(false)
 				continue
 			}
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    pin.UserName,
-			"network": pin.NetworkName,
-		}).Infof("successfully processed pin for %s", pin.CID)
+		qm.LogInfo("successfully processed pin request")
 		d.Ack(false)
 	}
 	return nil
@@ -393,13 +230,6 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 		service.
 			WithField("error", err.Error()).
 			Error("failed to initialize connection to minio")
-		return err
-	}
-	qmEmail, err := Initialize(EmailSendQueue, cfg.RabbitMQ.URL, true, false)
-	if err != nil {
-		service.
-			WithField("error", err.Error()).
-			Error("failed to initialize email send queue connection")
 		return err
 	}
 	qmPin, err := Initialize(IpfsPinQueue, cfg.RabbitMQ.URL, true, false)
@@ -443,20 +273,6 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 			}
 			if !canAccess {
 				qm.refundCredits(ipfsFile.UserName, "file", ipfsFile.CreditCost, db)
-				addresses := []string{}
-				addresses = append(addresses, ipfsFile.UserName)
-				es := EmailSend{
-					Subject:     IpfsPrivateNetworkUnauthorizedSubject,
-					Content:     fmt.Sprintf("Unauthorized access to IPFS private network %s", ipfsFile.NetworkName),
-					ContentType: "",
-					UserNames:   addresses,
-				}
-				err = qmEmail.PublishMessage(es)
-				if err != nil {
-					fileContext.
-						WithField("error", err.Error()).
-						Error("failed to publish message to email send queue")
-				}
 				fileContext.Error("unauthorized access to private network")
 				d.Ack(false)
 				continue
@@ -474,20 +290,6 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 			ipfsManager, err = rtfs.Initialize("", apiURL)
 			if err != nil {
 				qm.refundCredits(ipfsFile.UserName, "file", ipfsFile.CreditCost, db)
-				addresses := []string{}
-				addresses = append(addresses, ipfsFile.UserName)
-				es := EmailSend{
-					Subject:     IpfsInitializationFailedSubject,
-					Content:     fmt.Sprintf("Connection to IPFS failed due to the following error %s", err),
-					ContentType: "",
-					UserNames:   addresses,
-				}
-				errOne := qmEmail.PublishMessage(es)
-				if errOne != nil {
-					fileContext.
-						WithField("error", err.Error()).
-						Error("failed to publish message to email send queue")
-				}
 				fileContext.
 					WithField("error", err.Error()).
 					Error("failed to initialize connection to private ipfs network")
@@ -513,20 +315,6 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 		resp, err := ipfsManager.Add(obj)
 		if err != nil {
 			qm.refundCredits(ipfsFile.UserName, "file", ipfsFile.CreditCost, db)
-			addresses := []string{}
-			addresses = append(addresses, ipfsFile.UserName)
-			es := EmailSend{
-				Subject:     IpfsFileFailedSubject,
-				Content:     fmt.Sprintf(IpfsFileFailedContent, ipfsFile.ObjectName, ipfsFile.NetworkName),
-				ContentType: "",
-				UserNames:   addresses,
-			}
-			errOne := qmEmail.PublishMessage(es)
-			if errOne != nil {
-				fileContext.
-					WithField("error", err.Error()).
-					Error("failed to publish message to email send queue")
-			}
 			fileContext.
 				WithField("error", err.Error()).
 				Info("failed to add file to ipfs")

--- a/queue/ipns.go
+++ b/queue/ipns.go
@@ -2,11 +2,9 @@ package queue
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/RTradeLtd/Temporal/models"
 	"github.com/RTradeLtd/config"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/RTradeLtd/Temporal/rtfs"
 	"github.com/jinzhu/gorm"
@@ -17,45 +15,23 @@ import (
 func (qm *QueueManager) ProcessIPNSEntryCreationRequests(msgs <-chan amqp.Delivery, db *gorm.DB, cfg *config.TemporalConfig) error {
 	ipfsManager, err := rtfs.Initialize("", cfg.IPFS.APIConnection.Host+":"+cfg.IPFS.APIConnection.Port)
 	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to initialize connection to ipfs")
+		qm.LogError(err, "failed to initialize connection to ipfs")
 		return err
 	}
-	err = ipfsManager.CreateKeystoreManager()
-	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to create keystore manager")
+	if err = ipfsManager.CreateKeystoreManager(); err != nil {
+		qm.LogError(err, "failed to create keystore manager")
 		return err
 	}
 	ipnsManager := models.NewIPNSManager(db)
 	userManager := models.NewUserManager(db)
 	networkManager := models.NewHostedIPFSNetworkManager(db)
-	qmEmail, err := Initialize(IpnsEntryQueue, cfg.RabbitMQ.URL, true, false)
-	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to initialize connection to email send queue")
-		return err
-	}
-	qm.Logger.WithFields(log.Fields{
-		"service": qm.QueueName,
-	}).Info("Processing ipns entry requests")
+	qm.LogInfo("processing ipns entry creation requests")
 	for d := range msgs {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("new message detected")
+		qm.LogInfo("neww message detected")
 		ie := IPNSEntry{}
 		err = json.Unmarshal(d.Body, &ie)
 		if err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"error":   err.Error(),
-			}).Error("failed to unmarshal message")
+			qm.LogError(err, "failed to unmarshal message")
 			d.Ack(false)
 			continue
 		}
@@ -64,121 +40,38 @@ func (qm *QueueManager) ProcessIPNSEntryCreationRequests(msgs <-chan amqp.Delive
 			canAccess, err := userManager.CheckIfUserHasAccessToNetwork(ie.UserName, ie.NetworkName)
 			if err != nil {
 				qm.refundCredits(ie.UserName, "ipns", ie.CreditCost, db)
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-					"error":   err.Error(),
-				}).Error("error checking for private network access")
+				qm.LogError(err, "failed to check for private network access")
 				d.Ack(false)
 				continue
 			}
 			if !canAccess {
 				qm.refundCredits(ie.UserName, "ipns", ie.CreditCost, db)
-				addresses := []string{}
-				addresses = append(addresses, ie.UserName)
-				es := EmailSend{
-					Subject:     IpfsPrivateNetworkUnauthorizedSubject,
-					Content:     fmt.Sprintf("Unauthorized access to IPFS private network %s", ie.NetworkName),
-					ContentType: "",
-					UserNames:   addresses,
-				}
-				err = qmEmail.PublishMessage(es)
-				if err != nil {
-					qm.Logger.WithFields(log.Fields{
-						"service": qm.QueueName,
-						"error":   err.Error(),
-					}).Error("failed to publish message to email send queue")
-				}
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-				}).Error("unauthorized access to private network")
+				qm.LogError(err, "invalid private network access")
 				d.Ack(false)
 				continue
 			}
 			apiURLName, err := networkManager.GetAPIURLByName(ie.NetworkName)
 			if err != nil {
 				qm.refundCredits(ie.UserName, "ipns", ie.CreditCost, db)
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to get ipfs api url by name")
+				qm.LogError(err, "failed to find ipfs api url")
 				d.Ack(false)
 				continue
 			}
 			apiURL = apiURLName
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    ie.UserName,
-				"network": ie.NetworkName,
-			}).Info("initializing connection to private ipfs network")
+			qm.LogInfo("initializing connection to private ipfs network")
 			ipfsManager, err = rtfs.Initialize("", apiURL)
 			if err != nil {
 				qm.refundCredits(ie.UserName, "ipns", ie.CreditCost, db)
-				addresses := []string{}
-				addresses = append(addresses, ie.UserName)
-				es := EmailSend{
-					Subject:     IpfsInitializationFailedSubject,
-					Content:     fmt.Sprintf("Connection to IPFS failed due to the following error %s", err),
-					ContentType: "",
-					UserNames:   addresses,
-				}
-				errOne := qmEmail.PublishMessage(es)
-				if errOne != nil {
-					qm.Logger.WithFields(log.Fields{
-						"service": qm.QueueName,
-						"error":   errOne.Error(),
-					}).Error("failed to publish message to email send queue")
-				}
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to initialize conenction to private ipfs network")
+				qm.LogError(err, "failed to initialized connection to private ifps network")
 				d.Ack(false)
 				continue
 			}
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    ie.UserName,
-			"network": ie.NetworkName,
-		}).Info("publishing ipns entry")
+		qm.LogInfo("publishing ipns entry")
 		response, err := ipfsManager.PublishToIPNSDetails(ie.CID, ie.Key, ie.LifeTime, ie.TTL, ie.Resolve)
 		if err != nil {
 			qm.refundCredits(ie.UserName, "ipns", ie.CreditCost, db)
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    ie.UserName,
-				"network": ie.NetworkName,
-			}).Error("failed to publish ipns entry")
-			formattedContent := fmt.Sprintf(IpnsEntryFailedContent, ie.CID, ie.Key, err)
-			addresses := []string{}
-			addresses = append(addresses, ie.UserName)
-			es := EmailSend{
-				Subject:     IpnsEntryFailedSubject,
-				Content:     formattedContent,
-				ContentType: "",
-				UserNames:   addresses,
-			}
-			errOne := qmEmail.PublishMessage(es)
-			if errOne != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"error":   errOne.Error(),
-				}).Error("failed to publish message to email send queue")
-			}
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"user":    ie.UserName,
-				"network": ie.NetworkName,
-				"error":   err.Error(),
-			}).Error("failed to publish entry to ipns")
+			qm.LogError(err, "failed to publish ipns entry")
 			d.Ack(false)
 			continue
 		}
@@ -192,12 +85,7 @@ func (qm *QueueManager) ProcessIPNSEntryCreationRequests(msgs <-chan amqp.Delive
 				ie.LifeTime,
 				ie.TTL,
 			); err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to update IPNS entry in database")
+				qm.LogError(err, "failed to update ipns entry in database")
 				d.Ack(false)
 				continue
 			}
@@ -212,21 +100,12 @@ func (qm *QueueManager) ProcessIPNSEntryCreationRequests(msgs <-chan amqp.Delive
 				ie.LifeTime,
 				ie.TTL,
 			); err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    ie.UserName,
-					"network": ie.NetworkName,
-					"error":   err.Error(),
-				}).Error("failed to update IPNS entry in database")
+				qm.LogError(err, "failed to create ipns entry in database")
 				d.Ack(false)
 				continue
 			}
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"user":    ie.UserName,
-			"network": ie.NetworkName,
-		}).Info("successfully published entry to ipns")
+		qm.LogInfo("successfully published and saved ipns entry")
 		d.Ack(false)
 	}
 	return nil

--- a/queue/log.go
+++ b/queue/log.go
@@ -1,0 +1,18 @@
+package queue
+
+import log "github.com/sirupsen/logrus"
+
+// LogError is a wrapper used to log an error message
+func (qm *QueueManager) LogError(err error, message string) {
+	qm.Logger.WithFields(log.Fields{
+		"service": qm.Service,
+		"error":   err.Error(),
+	}).Error(message)
+}
+
+// LogInfo is a wrapper used to log an info message
+func (qm *QueueManager) LogInfo(message string) {
+	qm.Logger.WithFields(log.Fields{
+		"service": qm.Service,
+	}).Info(message)
+}

--- a/queue/log.go
+++ b/queue/log.go
@@ -3,11 +3,27 @@ package queue
 import log "github.com/sirupsen/logrus"
 
 // LogError is a wrapper used to log an error message
-func (qm *QueueManager) LogError(err error, message string) {
-	qm.Logger.WithFields(log.Fields{
+func (qm *QueueManager) LogError(err error, message string, fields ...interface{}) {
+	// base entry
+	entry := qm.Logger.WithFields(log.Fields{
 		"service": qm.Service,
-		"error":   err.Error(),
-	}).Error(message)
+	})
+
+	// parse additional fields if there are any
+	if fields != nil {
+		for i := 0; i < len(fields); i += 2 {
+			if i+1 < len(fields) {
+				entry = entry.WithField(fields[i].(string), fields[i+1])
+			}
+		}
+	}
+
+	// write the actual log
+	if err == nil {
+		entry.Error(message)
+	} else {
+		entry.WithField("error", err.Error()).Error(message)
+	}
 }
 
 // LogInfo is a wrapper used to log an info message

--- a/queue/log_test.go
+++ b/queue/log_test.go
@@ -1,0 +1,57 @@
+package queue_test
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/RTradeLtd/Temporal/queue"
+)
+
+func TestQueue_LogError(t *testing.T) {
+	qm, err := queue.Initialize(queue.IpfsPinQueue, testRabbitAddress, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type args struct {
+		err     error
+		message string
+		fields  []interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantLog  string
+		wantResp string
+	}{
+		{"with err no message", args{errors.New("hi"), "", nil}, "hi", "hi"},
+		{"with err and message", args{errors.New("hi"), "bye", nil}, "hi", "bye"},
+		{"with message and no err", args{nil, "bye", nil}, "bye", "bye"},
+		{"no message and no err", args{nil, "", nil}, "", ""},
+		{"message and additional fields", args{nil, "hi", []interface{}{"wow", "amazing"}}, "amazing", "hi"},
+		{"message and odd fields should ignore fields", args{nil, "hi", []interface{}{"wow"}}, "hi", "hi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			qm.Logger.Out = &buf
+			// log error and execute callback
+			if tt.args.fields != nil {
+				qm.LogError(tt.args.err, tt.args.message, tt.args.fields...)
+			} else {
+				qm.LogError(tt.args.err, tt.args.message)
+			}
+
+			// check log output
+			b, err := ioutil.ReadAll(&buf)
+			if err != nil {
+				t.Error(err)
+			}
+			if !strings.Contains(string(b), tt.wantLog) {
+				t.Errorf("got %s, want %s", string(b), tt.wantLog)
+			}
+		})
+	}
+}

--- a/queue/log_test.go
+++ b/queue/log_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/RTradeLtd/Temporal/queue"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestQueue_LogError(t *testing.T) {
-	qm, err := queue.Initialize(queue.IpfsPinQueue, testRabbitAddress, false, true)
-	if err != nil {
-		t.Fatal(err)
+	qm := queue.QueueManager{
+		Logger: log.New(),
 	}
 	type args struct {
 		err     error

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -10,7 +10,7 @@ import (
 
 // ProcessMailSends is a function used to process mail send queue messages
 func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config.TemporalConfig) error {
-	mm, err := mail.GenerateMailManager(tCfg)
+	mm, err := mail.NewManager(tCfg)
 	if err != nil {
 		qm.LogError(err, "failed to generate mail manager")
 		return err

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -20,10 +20,7 @@ func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config
 		qm.LogInfo("detected new message")
 		es := EmailSend{}
 		if err = json.Unmarshal(d.Body, &es); err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"error":   err.Error(),
-			}).Error("failed to unmarshal message")
+			qm.LogError(err, "failed to unmarshal message")
 			d.Ack(false)
 			continue
 		}
@@ -31,11 +28,7 @@ func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config
 		for k, v := range es.Emails {
 			_, err = mm.SendEmail(es.Subject, es.Content, es.ContentType, es.UserNames[k], v)
 			if err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    k,
-					"error":   err.Error(),
-				}).Error("failed to send email")
+				qm.LogError(err, "failed to send email")
 				d.Ack(false)
 				emailSent = false
 				continue

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/RTradeLtd/Temporal/mail"
 	"github.com/RTradeLtd/config"
-	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 )
 
@@ -13,26 +12,16 @@ import (
 func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config.TemporalConfig) error {
 	mm, err := mail.GenerateMailManager(tCfg)
 	if err != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"error":   err.Error(),
-		}).Error("failed to generate mail manager")
+		qm.LogError(err, "failed to generate mail manager")
 		return err
 	}
-	qm.Logger.WithFields(log.Fields{
-		"service": qm.QueueName,
-	}).Info("process email sends")
+	qm.LogInfo("processing email sends")
 	for d := range msgs {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("detected new message")
+		qm.LogInfo("detected new message")
 		es := EmailSend{}
 		err = json.Unmarshal(d.Body, &es)
 		if err != nil {
-			qm.Logger.WithFields(log.Fields{
-				"service": qm.QueueName,
-				"error":   err.Error(),
-			}).Error("failed to unmarshal message")
+			qm.LogError(err, "failed to unmarshal message")
 			d.Ack(false)
 			continue
 		}
@@ -40,11 +29,7 @@ func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config
 		for _, v := range es.UserNames {
 			resp, err := mm.UserManager.FindEmailByUserName(v)
 			if err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    v,
-					"error":   err.Error(),
-				}).Error("failed to find email by user name")
+				qm.LogError(err, "failed to find email by user name")
 				d.Ack(false)
 				continue
 			}
@@ -53,17 +38,12 @@ func (qm *QueueManager) ProcessMailSends(msgs <-chan amqp.Delivery, tCfg *config
 		for k, v := range emails {
 			_, err = mm.SendEmail(es.Subject, es.Content, es.ContentType, k, v)
 			if err != nil {
-				qm.Logger.WithFields(log.Fields{
-					"service": qm.QueueName,
-					"user":    k,
-					"error":   err.Error(),
-				}).Error("failed to send email")
+				qm.LogError(err, "failed to send email")
+				d.Ack(false)
+				continue
 			}
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-			"users":   es.UserNames,
-		}).Info("successfully sent emails")
+		qm.LogInfo("successfuly sent email(s)")
 		d.Ack(false)
 	}
 	return nil

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -142,7 +142,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 		Password:       cfg.Database.Password,
 		Address:        cfg.Database.URL,
 		Port:           cfg.Database.Port,
-		SSLModeDisable: false,
+		SSLModeDisable: true,
 	})
 	if err != nil {
 		return err

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -98,15 +98,14 @@ func setupConnection(connectionURL string) (*amqp.Connection, error) {
 	return conn, nil
 }
 
+// OpenChannel is used to open a channel with rabbitmq
 func (qm *QueueManager) OpenChannel() error {
 	ch, err := qm.Connection.Channel()
 	if err != nil {
 		return err
 	}
 	if qm.Logger != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("channel opened")
+		qm.LogInfo("channel opened")
 	}
 	qm.Channel = ch
 	return nil
@@ -128,9 +127,7 @@ func (qm *QueueManager) DeclareQueue() error {
 		return err
 	}
 	if qm.Logger != nil {
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("queue declared")
+		qm.LogInfo("queue declared")
 	}
 	qm.Queue = &q
 	return nil
@@ -163,9 +160,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 		if err != nil {
 			return err
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("queue bound")
+		qm.LogInfo("queue bound")
 	case PinExchange:
 		err = qm.Channel.QueueBind(
 			qm.QueueName, // name of the queue
@@ -177,9 +172,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 		if err != nil {
 			return err
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("queue bound")
+		qm.LogInfo("queue bound")
 	case IpfsKeyExchange:
 		err = qm.Channel.QueueBind(
 			qm.QueueName,    // name of the queue
@@ -191,9 +184,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 		if err != nil {
 			return err
 		}
-		qm.Logger.WithFields(log.Fields{
-			"service": qm.QueueName,
-		}).Info("queue bound")
+		qm.LogInfo("queue bound")
 	default:
 		break
 	}
@@ -248,7 +239,7 @@ func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, c
 			return err
 		}
 	default:
-		log.Fatal("invalid queue name")
+		return errors.New("invalid queue name")
 	}
 	return nil
 }
@@ -310,6 +301,7 @@ func (qm *QueueManager) PublishMessage(body interface{}) error {
 	return nil
 }
 
+// Close is used to close our queue connection
 func (qm *QueueManager) Close() error {
 	return qm.Connection.Close()
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -138,11 +138,10 @@ func (qm *QueueManager) DeclareQueue() error {
 // Perhaps the error was temporary, and we allow it to be retried?
 func (qm *QueueManager) ConsumeMessage(consumer, dbPass, dbURL, dbUser string, cfg *config.TemporalConfig) error {
 	db, err := database.OpenDBConnection(database.DBOptions{
-		User:           cfg.Database.Username,
-		Password:       cfg.Database.Password,
-		Address:        cfg.Database.URL,
-		Port:           cfg.Database.Port,
-		SSLModeDisable: true,
+		User:     cfg.Database.Username,
+		Password: cfg.Database.Password,
+		Address:  cfg.Database.URL,
+		Port:     cfg.Database.Port,
 	})
 	if err != nil {
 		return err

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -38,7 +38,7 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestQueues(t *testing.T) {
-	qm, err := queue.Initialize(queue.IpfsPinQueue, testRabbitAddress, false, false)
+	qm, err := queue.Initialize(queue.IpfsPinQueue, testRabbitAddress, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,8 +49,18 @@ func TestQueues(t *testing.T) {
 		HoldTimeInMonths: 10,
 	}
 
-	err = qm.PublishMessageWithExchange(pin, queue.PinExchange)
-	if err != nil {
+	if err = qm.PublishMessageWithExchange(pin, queue.PinExchange); err != nil {
+		t.Fatal(err)
+	}
+	qm, err = queue.Initialize(queue.EmailSendQueue, testRabbitAddress, true, false)
+	es := queue.EmailSend{
+		Subject:     "test email",
+		Content:     "this is a test email",
+		ContentType: "text/html",
+		UserNames:   []string{"postables"},
+		Emails:      []string{"postables@rtradetechnologies.com"},
+	}
+	if err = qm.PublishMessage(es); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/queue/types.go
+++ b/queue/types.go
@@ -132,6 +132,7 @@ type EmailSend struct {
 	Content     string   `json:"content"`
 	ContentType string   `json:"content_type"`
 	UserNames   []string `json:"user_names"`
+	Emails      []string `json:"emails,omitempty"`
 }
 
 // IPNSEntry is used to hold relevant information needed to process IPNS entry creation requests


### PR DESCRIPTION
## :construction_worker: Purpose
The queue logging system was extremely verbose, it has been cleaned up.
In order to "activate" your email, you need to generate an email verification token and validate it.


## :rocket: Changes
`LogInfo` and `LogError` helpers
Email requires verification to prevent "spam" (this will be followed up by a validation during account signup in the future)
Email notifications during queue processing have been temporarily removed until a "smoother" system can be designed

## :warning: Breaking Changes
None

