### PR TITLE
deps: lock go-ipfs-api to v2.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master-rtrade"
-  digest = "1:057ef275777e16de287ddbe39ae5590ab1acfa6ccb3d86f3410b998f7ce59b05"
+  digest = "1:7304b11d7d7cce4b00d32075b56d2266443f12af31ac7777eb143f3f0ee870dd"
   name = "github.com/RTradeLtd/go-ipfs-api"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7a707aa6805a8737f57d6623f62fe5b37862626a"
+  revision = "08c411b67689a098b484b5b18ada2a78f48990b1"
+  version = "v2.0.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@ ignored = ["github.com/karalabe/hid", "github.com/satori/go.uuid", "github.com/i
 
 [[constraint]]
   name = "github.com/RTradeLtd/go-ipfs-api"
-  branch = "master-rtrade"
+  version = "v2.0.0"
 
 # IPFS
 

--- a/vendor/github.com/RTradeLtd/go-ipfs-api/README.md
+++ b/vendor/github.com/RTradeLtd/go-ipfs-api/README.md
@@ -1,5 +1,64 @@
 # go-ipfs-api
 
-# READ BEFORE USING
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![GoDoc](https://godoc.org/github.com/ipfs/go-ipfs-api?status.svg)](https://godoc.org/github.com/ipfs/go-ipfs-api)
+[![Build Status](https://travis-ci.org/ipfs/go-ipfs-api.svg)](https://travis-ci.org/ipfs/go-ipfs-api) 
 
-This particular branch contains modifications that are not in the upstream version of this repo, and is the branch used by Temporal
+![](https://camo.githubusercontent.com/651f7045071c78042fec7f5b9f015e12589af6d5/68747470733a2f2f697066732e696f2f697066732f516d514a363850464d4464417367435a76413155567a7a6e3138617356636637485676434467706a695343417365)
+
+> An unofficial go interface to ipfs's HTTP API
+
+## Install
+
+```sh
+go get -u github.com/ipfs/go-ipfs-api
+```
+
+This will download the source into `$GOPATH/src/github.com/ipfs/go-ipfs-api`.
+
+## Usage
+
+See [the godocs](https://godoc.org/github.com/ipfs/go-ipfs-api) for details on available methods. This should match the specs at [ipfs/specs](https://github.com/ipfs/specs/tree/master/public-api); however, there are still some methods which are not accounted for. If you would like to add any of them, see the contribute section below.
+
+### Example
+
+Add a file with the contents "hello world!":
+
+```go
+package main
+
+import (
+	"strings"
+    "os"
+
+    shell "github.com/ipfs/go-ipfs-api"
+)
+
+func main() {
+	// Where your local node is running on localhost:5001
+	sh := shell.NewShell("localhost:5001")
+	cid, err := sh.Add(strings.NewReader("hello world!"))
+	if err != nil {
+        fmt.Fprintf(os.Stderr, "error: %s", err)
+        os.Exit(1)
+	}
+    fmt.Println("added %s", cid)
+}
+```
+
+For a more complete example, please see: https://github.com/ipfs/go-ipfs-api/blob/master/tests/main.go
+
+## Contribute
+
+Contributions are welcome! Please check out the [issues](https://github.com/ipfs/go-ipfs-api/issues).
+
+### Want to hack on IPFS?
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+
+## License
+
+MIT


### PR DESCRIPTION
## :construction_worker: Purpose

Fix issues building vendor due to changes to https://github.com/RTradeLtd/go-ipfs

## :rocket: Changes

Lock to tag v2.0.0

## :warning: Breaking Changes

none
