### PR TITLE
Encrypted Uploads Refactor: TEM-109

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,6 +38,7 @@ type API struct {
 	um      *models.UserManager
 	im      *models.IpnsManager
 	dm      *models.DropManager
+	ue      *models.EncryptedUploadManager
 	ipfs    *rtfs.IpfsManager
 	l       *log.Logger
 	service string
@@ -125,6 +126,7 @@ func new(cfg *config.TemporalConfig, router *gin.Engine, debug bool, out io.Writ
 		um:      models.NewUserManager(dbm.DB),
 		im:      models.NewIPNSManager(dbm.DB),
 		dm:      models.NewDropManager(dbm.DB),
+		ue:      models.NewEncryptedUploadManager(dbm.DB),
 		ipfs:    ipfsManager,
 	}, nil
 }
@@ -292,6 +294,10 @@ func (api *API) setupRoutes() {
 	// frontend
 	frontend := v1.Group("/frontend", authware...)
 	{
+		uploads := frontend.Group("/uploads")
+		{
+			uploads.GET("/encrypted", api.getEncryptedUploadsForUser)
+		}
 		cost := frontend.Group("/cost")
 		{
 			calculate := cost.Group("/calculate")

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/jinzhu/gorm"
+
 	"github.com/RTradeLtd/Temporal/eh"
 	"github.com/RTradeLtd/Temporal/utils"
 	"github.com/gin-gonic/gin"
@@ -91,12 +93,12 @@ func (api *API) calculateFileCost(c *gin.Context) {
 func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 	username := GetAuthenticatedUserFromContext(c)
 	uploads, err := api.ue.FindUploadsByUser(username)
-	if err != nil {
+	if err != nil && err != gorm.ErrRecordNotFound {
 		api.LogError(err, eh.UploadSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	if len(*uploads) == 0 {
-		Respond(c, http.StatusOK, gin.H{"response": "user has no encrypted uploads"})
+		Respond(c, http.StatusOK, gin.H{"response": "no encrypted uploads found, try them out :D"})
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": uploads})

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -95,5 +95,9 @@ func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 		api.LogError(err, eh.UploadSearchError)(c, http.StatusBadRequest)
 		return
 	}
+	if len(*uploads) == 0 {
+		Respond(c, http.StatusOK, gin.H{"response": "user has no encrypted uploads"})
+		return
+	}
 	Respond(c, http.StatusOK, gin.H{"response": uploads})
 }

--- a/api/routes_frontend.go
+++ b/api/routes_frontend.go
@@ -86,3 +86,14 @@ func (api *API) calculateFileCost(c *gin.Context) {
 	cost := utils.CalculateFileCost(holdTimeInt, file.Size, isPrivate)
 	Respond(c, http.StatusOK, gin.H{"response": cost})
 }
+
+// GetEncryptedUploadsForUser is used to get all the encrypted uploads a user has
+func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
+	username := GetAuthenticatedUserFromContext(c)
+	uploads, err := api.ue.FindUploadsByUser(username)
+	if err != nil {
+		api.LogError(err, eh.UploadSearchError)(c, http.StatusBadRequest)
+		return
+	}
+	Respond(c, http.StatusOK, gin.H{"response": uploads})
+}

--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -170,13 +170,13 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	logger.Debugf("file %s stored in minio", objectName)
 
 	ifp := queue.IPFSFile{
+		FileName:         fileHandler.Filename,
 		BucketName:       FilesUploadBucket,
 		ObjectName:       objectName,
 		UserName:         username,
 		NetworkName:      "public",
 		HoldTimeInMonths: holdTimeInMonths,
 		CreditCost:       cost,
-
 		// if passphrase was provided, this file is encrypted
 		Encrypted: c.PostForm("passphrase") != "",
 	}

--- a/database/database.go
+++ b/database/database.go
@@ -11,12 +11,13 @@ import (
 )
 
 var (
-	UploadObj        *models.Upload
-	UserObj          *models.User
-	PaymentObj       *models.Payments
-	IpnsObj          *models.IPNS
-	HostedIpfsNetObj *models.HostedIPFSPrivateNetwork
-	DropObj          *models.Drop
+	UploadObj          *models.Upload
+	EncryptedUploadObj *models.EncryptedUpload
+	UserObj            *models.User
+	PaymentObj         *models.Payments
+	IpnsObj            *models.IPNS
+	HostedIpfsNetObj   *models.HostedIPFSPrivateNetwork
+	DropObj            *models.Drop
 )
 
 type DatabaseManager struct {

--- a/database/database.go
+++ b/database/database.go
@@ -66,6 +66,7 @@ func (dbm *DatabaseManager) RunMigrations() {
 	dbm.DB.AutoMigrate(IpnsObj)
 	dbm.DB.AutoMigrate(HostedIpfsNetObj)
 	dbm.DB.AutoMigrate(DropObj)
+	dbm.DB.AutoMigrate(EncryptedUploadObj)
 	//dbm.DB.Model(userObj).Related(uploadObj.Users)
 }
 

--- a/models/encrypted.go
+++ b/models/encrypted.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"strings"
+
+	"github.com/jinzhu/gorm"
+)
+
+// EncryptedUpload is an uploaded that has been encrypted by Temporal
+type EncryptedUpload struct {
+	gorm.Model
+	UserName      string `gorm:"type:varchar(255)"`
+	FileName      string `gorm:"type:varchar(255)"`
+	FileNameUpper string `gorm:"type:varchar(255)"`
+	FileNameLower string `gorm:"type:varchar(255)"`
+	NetworkName   string `gorm:"type:varchar(255)"`
+	IPFSHash      string `gorm:"type:varchar(255)"`
+}
+
+// EncryptedUploadManager is used to manipulate encrypted uplaods
+type EncryptedUploadManager struct {
+	DB *gorm.DB
+}
+
+// NewEncryptedUploadManager is used to generate our db helper
+func NewEncryptedUploadManager(db *gorm.DB) *EncryptedUploadManager {
+	return &EncryptedUploadManager{DB: db}
+}
+
+// NewUpload is used to store a new encrypted upload in the database
+func (ecm *EncryptedUploadManager) NewUpload(username, filename, networname, ipfsHash string) (*EncryptedUpload, error) {
+	eu := &EncryptedUpload{
+		UserName:      username,
+		FileName:      filename,
+		FileNameLower: strings.ToLower(filename),
+		FileNameUpper: strings.ToUpper(filename),
+		NetworkName:   networname,
+		IPFSHash:      ipfsHash,
+	}
+
+	if err := ecm.DB.Create(eu).Error; err != nil {
+		return nil, err
+	}
+	return eu, nil
+}
+
+// FindUploadsByUser is used to find all uploads for a given user
+func (ecm *EncryptedUploadManager) FindUploadsByUser(username string) (*[]EncryptedUpload, error) {
+	uploads := []EncryptedUpload{}
+	if err := ecm.DB.Where("user_name = ?", username).Find(&uploads).Error; err != nil {
+		return nil, err
+	}
+	return &uploads, nil
+}

--- a/models/encrypted_test.go
+++ b/models/encrypted_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestEncryptedUploads(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 	cfg, err := config.LoadConfig(testCfgPath)
 	if err != nil {
 		t.Fatal(err)

--- a/models/encrypted_test.go
+++ b/models/encrypted_test.go
@@ -1,0 +1,69 @@
+package models_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/RTradeLtd/Temporal/models"
+	"github.com/RTradeLtd/config"
+)
+
+func TestEncryptedUploads(t *testing.T) {
+	cfg, err := config.LoadConfig(testCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := openDatabaseConnection(t, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecm := models.NewEncryptedUploadManager(db)
+	type args struct {
+		user    string
+		file    string
+		network string
+		hash    string
+	}
+	tests := []args{
+		args{"user1", "file1", "network1", "hash1"},
+		args{"user1", "file2", "public", "hash2"},
+	}
+	upload1, err := ecm.NewUpload(tests[0].user, tests[0].file, tests[0].network, tests[0].hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Delete(upload1)
+	if upload1.FileNameUpper != strings.ToUpper(tests[0].file) {
+		t.Fatal("file name to upper failed")
+
+	}
+	if upload1.FileNameLower != strings.ToLower(tests[0].file) {
+		t.Fatal("file name to lower failed")
+	}
+	uploads, err := ecm.FindUploadsByUser(tests[0].user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*uploads) != 1 {
+		t.Fatal("user should only have 1 upload")
+	}
+	upload2, err := ecm.NewUpload(tests[1].user, tests[1].file, tests[1].network, tests[1].hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Delete(upload2)
+	if upload2.FileNameUpper != strings.ToUpper(tests[1].file) {
+		t.Fatal("file name to upper failed")
+
+	}
+	if upload2.FileNameLower != strings.ToLower(tests[1].file) {
+		t.Fatal("file name to lower failed")
+	}
+	uploads, err = ecm.FindUploadsByUser(tests[0].user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*uploads) != 2 {
+		t.Fatal("user should have exactly 2 uploads")
+	}
+}

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -409,6 +409,7 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 			Error("failed to initialize pin queue connection")
 		return err
 	}
+	ue := models.NewEncryptedUploadManager(db)
 	userManager := models.NewUserManager(db)
 	networkManager := models.NewHostedIPFSNetworkManager(db)
 	uploadManager := models.NewUploadManager(db)
@@ -591,7 +592,22 @@ func (qm *QueueManager) ProccessIPFSFiles(msgs <-chan amqp.Delivery, cfg *config
 				continue
 			}
 		}
-
+		// if encrypted upload, do some special processing
+		if ipfsFile.Encrypted {
+			if _, err = ue.NewUpload(
+				ipfsFile.UserName,
+				ipfsFile.FileName,
+				ipfsFile.NetworkName,
+				resp,
+			); err != nil {
+				// we won't ack this, since we have already processed the upload and this is "extra processing"
+				// the object should still be removed from minio and ack+continue would prevent this from happening
+				// that being said, we will need to make sure we monitor errors properly
+				fileContext.
+					WithField("error", err.Error()).
+					Error("failed to upload database with encrypted upload")
+			}
+		}
 		fileContext.Info("removing object from minio")
 		err = minioManager.RemoveObject(ipfsFile.BucketName, ipfsFile.ObjectName)
 		if err != nil {

--- a/queue/types.go
+++ b/queue/types.go
@@ -86,6 +86,7 @@ type IPFSPin struct {
 
 // IPFSFile is our message for the ipfs file queue
 type IPFSFile struct {
+	FileName         string  `json:"file_name,omitempty"`
 	BucketName       string  `json:"bucket_name"`
 	ObjectName       string  `json:"object_name"`
 	UserName         string  `json:"user_name"`


### PR DESCRIPTION
## :construction_worker: Purpose
To make it easier to parse through encrypted uploads on the frontend, an additional db table was created.


## :rocket: Changes
Add a table where encrypted uploads have additional information stored
Add API call that lets the frontend retrieve this additional information


## :warning: Breaking Changes
None

