### PR TITLE
Advanced Upload Bug Fix: TEM-111

### DIFF
--- a/api/routes_rtfs.go
+++ b/api/routes_rtfs.go
@@ -170,6 +170,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	logger.Debugf("file %s stored in minio", objectName)
 
 	ifp := queue.IPFSFile{
+		MinioHostIP:      api.cfg.MINIO.Connection.IP,
 		FileSize:         fileHandler.Size,
 		FileName:         fileHandler.Filename,
 		BucketName:       FilesUploadBucket,

--- a/api/routes_rtfsp.go
+++ b/api/routes_rtfsp.go
@@ -177,6 +177,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	}
 	fmt.Println("file stored in minio")
 	ifp := queue.IPFSFile{
+		MinioHostIP:      api.cfg.MINIO.Connection.IP,
 		FileName:         fileHandler.Filename,
 		FileSize:         fileHandler.Size,
 		BucketName:       FilesUploadBucket,

--- a/queue/types.go
+++ b/queue/types.go
@@ -90,6 +90,8 @@ type IPFSPin struct {
 
 // IPFSFile is our message for the ipfs file queue
 type IPFSFile struct {
+	// MinioHostIP is the ip address of the minio host this object is stored on
+	MinioHostIP      string  `json:"minio_host_ip"`
 	FileName         string  `json:"file_name,omitempty"`
 	FileSize         int64   `json:"file_size,omitempty"`
 	BucketName       string  `json:"bucket_name"`


### PR DESCRIPTION
## :construction_worker: Purpose
Due to the way rabbitmq distributes tasks to process advanced file uploads (ie, encrypted uploads) 50% of the requests would land on a worker running on a server, whose corresponding minio instance wasn't storing the file, leading to failures.


## :rocket: Changes
Within the `IPFSFile` message used by rabbitmq, a field for the IP address of the minio host that is storing the file, is included.
Instead of connecting to minio when we start the `IPFSFile` queue,  connect to minio when we find out what instance of minio is hosting the appropriate file.

## :warning: Breaking Changes
None

