### PR TITLE
Chore/linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 script:
   # - docker run -v $(pwd):/mnt koalaman/shellcheck **/*.sh(e[' [[ ! `echo "$REPLY" | grep "vendor/" ` ]]'])
   - diff -u <(echo -n) <(gofmt -d -s `find . -type f -name '*.go' -not -path "./vendor/*"`)
-  - diff -u <(echo -n) <(golint `go list ./... | grep -v /vendor/`)
+  - golint `go list ./... | grep -v /vendor/`
   - go test -race -short -coverprofile=coverage.txt ./...
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
 
 script:
   # - docker run -v $(pwd):/mnt koalaman/shellcheck **/*.sh(e[' [[ ! `echo "$REPLY" | grep "vendor/" ` ]]'])
-  - go fmt ./...
-  - golint $(go list ./... | grep -v /vendor/) # golint doesn't ignore vendor
+  - diff -u <(echo -n) <(gofmt -d -s `find . -type f -name '*.go' -not -path "./vendor/*"`)
+  - diff -u <(echo -n) <(golint `go list ./... | grep -v /vendor/`)
   - go test -race -short -coverprofile=coverage.txt ./...
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
   # - docker run -v $(pwd):/mnt koalaman/shellcheck **/*.sh(e[' [[ ! `echo "$REPLY" | grep "vendor/" ` ]]'])
   - diff -u <(echo -n) <(gofmt -d -s `find . -type f -name '*.go' -not -path "./vendor/*"`)
   - golint `go list ./... | grep -v /vendor/`
+  # TODO: switch on hard fail
+  # diff -u <(echo -n) <(golint `go list ./... | grep -v /vendor/`)
   - go test -race -short -coverprofile=coverage.txt ./...
 
 after_success:

--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -24,7 +24,7 @@ var (
 )
 
 var commands = map[string]cmd.Cmd{
-	"api": cmd.Cmd{
+	"api": {
 		Blurb:       "start Temporal api server",
 		Description: "Start the API service used to interact with Temporal. Run with DEBUG=true to enable debug messages.",
 		Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -50,17 +50,17 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
-	"queue": cmd.Cmd{
+	"queue": {
 		Blurb:         "execute commands for various queues",
 		Description:   "Interact with Temporal's various queue APIs",
 		ChildRequired: true,
 		Children: map[string]cmd.Cmd{
-			"ipfs": cmd.Cmd{
+			"ipfs": {
 				Blurb:         "IPFS queue sub commands",
 				Description:   "Used to launch the various queues that interact with IPFS",
 				ChildRequired: true,
 				Children: map[string]cmd.Cmd{
-					"ipns-entry": cmd.Cmd{
+					"ipns-entry": {
 						Blurb:       "IPNS entry creation queue",
 						Description: "Listens to requests to create IPNS records",
 						Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -75,7 +75,7 @@ var commands = map[string]cmd.Cmd{
 							}
 						},
 					},
-					"pin": cmd.Cmd{
+					"pin": {
 						Blurb:       "Pin addition queue",
 						Description: "Listens to pin requests",
 						Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -90,7 +90,7 @@ var commands = map[string]cmd.Cmd{
 							}
 						},
 					},
-					"file": cmd.Cmd{
+					"file": {
 						Blurb:       "File upload queue",
 						Description: "Listens to file upload requests. Only applies to advanced uploads",
 						Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -105,7 +105,7 @@ var commands = map[string]cmd.Cmd{
 							}
 						},
 					},
-					"key-creation": cmd.Cmd{
+					"key-creation": {
 						Blurb:       "Key creation queue",
 						Description: fmt.Sprintf("Listen to key creation requests.\nMessages to this queue are broadcasted to all nodes"),
 						Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -120,7 +120,7 @@ var commands = map[string]cmd.Cmd{
 							}
 						},
 					},
-					"cluster": cmd.Cmd{
+					"cluster": {
 						Blurb:       "Cluster pin queue",
 						Description: "Listens to requests to pin content to the cluster",
 						Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -137,7 +137,7 @@ var commands = map[string]cmd.Cmd{
 					},
 				},
 			},
-			"dfa": cmd.Cmd{
+			"dfa": {
 				Blurb:       "Database file add queue",
 				Description: "Listens to file uploads requests. Only applies to simple upload route",
 				Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -152,7 +152,7 @@ var commands = map[string]cmd.Cmd{
 					}
 				},
 			},
-			"email-send": cmd.Cmd{
+			"email-send": {
 				Blurb:       "Email send queue",
 				Description: "Listens to requests to send emails",
 				Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -169,7 +169,7 @@ var commands = map[string]cmd.Cmd{
 			},
 		},
 	},
-	"migrate": cmd.Cmd{
+	"migrate": {
 		Blurb:       "run database migrations",
 		Description: "Runs our initial database migrations, creating missing tables, etc..",
 		Action: func(cfg config.TemporalConfig, args map[string]string) {
@@ -180,7 +180,7 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
-	"migrate-insecure": cmd.Cmd{
+	"migrate-insecure": {
 		Hidden:      true,
 		Blurb:       "run database migrations without SSL",
 		Description: "Runs our initial database migrations, creating missing tables, etc.. without SSL",
@@ -193,7 +193,7 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
-	"init": cmd.Cmd{
+	"init": {
 		PreRun:      true,
 		Blurb:       "initialize blank Temporal configuration",
 		Description: "Initializes a blank Temporal configuration template at CONFIG_DAG.",
@@ -207,7 +207,7 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
-	"user": cmd.Cmd{
+	"user": {
 		Hidden:      true,
 		Blurb:       "create a user",
 		Description: "Create a Temporal user. Provide args as username, password, email. Do not use in production.",
@@ -228,7 +228,7 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
-	"admin": cmd.Cmd{
+	"admin": {
 		Hidden:      true,
 		Blurb:       "assign user as an admin",
 		Description: "Assign an existing Temporal user as an administrator.",

--- a/models/encrypted_test.go
+++ b/models/encrypted_test.go
@@ -28,8 +28,8 @@ func TestEncryptedUploads(t *testing.T) {
 		hash    string
 	}
 	tests := []args{
-		args{"user1", "file1", "network1", "hash1"},
-		args{"user1", "file2", "public", "hash2"},
+		{"user1", "file1", "network1", "hash1"},
+		{"user1", "file2", "public", "hash2"},
 	}
 	upload1, err := ecm.NewUpload(tests[0].user, tests[0].file, tests[0].network, tests[0].hash)
 	if err != nil {


### PR DESCRIPTION
## :construction_worker: Purpose

Previously CI wouldnt fail if go fmt doesnt pass - this adds some stuff ive been using in ipfs-orchestrator to make sure code style is up to snuff

## :rocket: Changes

Enable hard failures if go fmt fails, and add a commented check on golint to enforce code styles

Eventually, we'll want to enable the golint check and fix everything (there are... a huge number of warnings haha)

## :warning: Breaking Changes

none
