### PR TITLE
Add Private Network Removal

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -338,6 +338,7 @@ func (api *API) setupRoutes() {
 			network.POST("/new", api.createHostedIPFSNetworkEntryInDatabase)
 			network.POST("/stop", api.stopIPFSPrivateNetwork)
 			network.POST("/start", api.startIPFSPrivateNetwork)
+			network.DELETE("/remove", api.removeIPFSPrivateNetwork)
 		}
 		ipfsRoutes := ipfsPrivate.Group("/ipfs")
 		{


### PR DESCRIPTION
## :construction_worker: Purpose
Last PR didn't include the removal route for private networks


## :rocket: Changes
Add a `DELETE` api call that allows removal of private networks


## :warning: Breaking Changes
None

