### PR TITLE
queue containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,7 @@ ENV CONFIG_DAG /temporal/config.json
 COPY ./testenv/config.json /temporal/config.json
 
 # Set default command
-ENTRYPOINT [ "temporal", "api" ]
+ENTRYPOINT [ "temporal" ]
+
+# Run API by default
+CMD [ "api" ]

--- a/temporal.yml
+++ b/temporal.yml
@@ -28,6 +28,69 @@ services:
       - CONFIG_DAG=/data/temporal/config.json
     volumes:
       - ${BASE}/data/temporal:/data/temporal
+  
+  queue-dfa:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue dfa
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+  
+  queue-email-send:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue email-send
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+
+  queue-ipfs-cluster:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue ipfs cluster
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+
+  queue-ipfs-file:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue ipfs file
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+
+  queue-ipfs-ipns-entry:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue ipfs ipns-entry
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+
+  queue-ipfs-key-creation:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue ipfs key-creation
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
+
+  queue-ipfs-pin:
+    image: rtradetech/temporal:${API}
+    network_mode: "host" # expose all
+    command: queue ipfs pin
+    environment:
+      - CONFIG_DAG=/data/temporal/config.json
+    volumes:
+      - ${BASE}/data/temporal:/data/temporal
 
   ipfs:
     image: ipfs/go-ipfs:v0.4.18

--- a/temporal.yml
+++ b/temporal.yml
@@ -8,7 +8,7 @@
 #   - Generally, component data goes in $BASE/data/$COMPONENT.
 #
 # Configuration:
-#   * temporal:
+#   * temporal, queue-*:
 #     - configuration file should be in data directory
 #     - set API in env to use desired version
 #   * ipfs, ipfs-cluster:


### PR DESCRIPTION
## :construction_worker: Purpose

Allow easy spin-up of containerized queue consumers.

## :rocket: Changes

Configurable `CMD` for image
docker-compose entries for all queues

## :warning: Breaking Changes

none

## Testing

I pushed a new image, tagged `canary`, with the Dockerfile changes. Havent tested myself yet but should be able to do:

```
env API=canary BASE=/my/dir docker-compose -f prod.yml up
```