### PR TITLE
cmd: fix incorrect logFilePath variable

### DIFF
--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -34,7 +34,7 @@ var (
 	db           *gorm.DB
 	ctx          context.Context
 	cancel       context.CancelFunc
-	logFilePath  = "/var/log/temporal"
+	logFilePath  = "/var/log/temporal/"
 )
 
 var commands = map[string]cmd.Cmd{


### PR DESCRIPTION
## :construction_worker: Purpose
The variable to hold the default log file path was incorrect


## :rocket: Changes
Change from `/var/log/temporal` to `/var/log/temporal/`


## :warning: Breaking Changes
None

