### PR TITLE
Fix Potential Bug With Advanced Upload Route

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -530,7 +530,7 @@ func (api *API) setupRoutes() error {
 	{
 		database.GET("/uploads", api.getUploadsFromDatabase)  // admin locked
 		database.GET("/uploads/:user", api.getUploadsForUser) // partial admin locked
-		database.GET("/uploads/encrypted", api.getEncryptedUploadsForUser)
+		database.GET("/encrypted/uploads", api.getEncryptedUploadsForUser)
 	}
 
 	// frontend

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -530,15 +530,12 @@ func (api *API) setupRoutes() error {
 	{
 		database.GET("/uploads", api.getUploadsFromDatabase)  // admin locked
 		database.GET("/uploads/:user", api.getUploadsForUser) // partial admin locked
+		database.GET("/uploads/encrypted", api.getEncryptedUploadsForUser)
 	}
 
 	// frontend
 	frontend := v2.Group("/frontend", authware...)
 	{
-		uploads := frontend.Group("/uploads")
-		{
-			uploads.GET("/encrypted", api.getEncryptedUploadsForUser)
-		}
 		cost := frontend.Group("/cost")
 		{
 			calculate := cost.Group("/calculate")

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -1510,7 +1510,7 @@ func Test_API_Routes_Database(t *testing.T) {
 	// test get encrypted uploads
 	// /api/v2/frontend/uploads/encrypted
 	if err := sendRequest(
-		api, "GET", "/api/v2/database/uploads/encrypted", 200, nil, nil, nil,
+		api, "GET", "/api/v2/database/encrypted/uploads", 200, nil, nil, nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -1399,14 +1399,6 @@ func Test_API_Routes_Frontend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// test get encrypted uploads
-	// /api/v2/frontend/uploads/encrypted
-	if err := sendRequest(
-		api, "GET", "/api/v2/frontend/uploads/encrypted", 200, nil, nil, nil,
-	); err != nil {
-		t.Fatal(err)
-	}
-
 	// test pin cost calculate
 	// /api/v2/frontend/cost/calculate/:hash/:holTime
 	var floatAPIResp floatAPIResponse
@@ -1513,6 +1505,14 @@ func Test_API_Routes_Database(t *testing.T) {
 	// validate the response code
 	if interfaceAPIResp.Code != 200 {
 		t.Fatal("bad api status code from api/v2/database/uploads")
+	}
+
+	// test get encrypted uploads
+	// /api/v2/frontend/uploads/encrypted
+	if err := sendRequest(
+		api, "GET", "/api/v2/database/uploads/encrypted", 200, nil, nil, nil,
+	); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"strconv"
 
@@ -118,7 +119,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	if _, err = miniManager.PutObject(objectName, openFile, fileHandler.Size,
 		mini.PutObjectOptions{
 			Bucket:            FilesUploadBucket,
-			EncryptPassphrase: c.PostForm("passphrase"),
+			EncryptPassphrase: html.UnescapeString(c.PostForm("passphrase")),
 		}); err != nil {
 		api.LogError(err, eh.MinioPutError,
 			"user", username)(c)

--- a/api/v2/routes_rtfsp_usage.go
+++ b/api/v2/routes_rtfsp_usage.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"strconv"
 	"time"
@@ -138,7 +139,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	fmt.Println("storing file in minio")
 	if _, err = miniManager.PutObject(objectName, openFile, fileHandler.Size, mini.PutObjectOptions{
 		Bucket:            FilesUploadBucket,
-		EncryptPassphrase: c.PostForm("passphrase"),
+		EncryptPassphrase: html.UnescapeString(c.PostForm("passphrase")),
 	}); err != nil {
 		api.LogError(err, eh.MinioPutError)
 		api.refundUserCredits(username, "private-file", cost)


### PR DESCRIPTION
## :construction_worker: Purpose
Passing in passphrase via post form can result in certain characters being html escaped.
Changed the encrypted uploads get route to be grouped under database calls.

## :rocket: Changes
Add an `html.UnescapeString` to passphrase parameter
Change `/api/v2/frontend/uploads/encrypted` to `/api/v2/database/uploads/encrypted`

## :warning: Breaking Changes
Previous reliance on the call path for getting encrypted uploads will need to be changed.

