### PR TITLE
Add API Server Closure

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -316,7 +316,7 @@ func (api *API) ListenAndServe(ctx context.Context, addr string, tlsConfig *TLSC
 		case err := <-errChan:
 			return err
 		case <-ctx.Done():
-			return nil
+			return server.Close()
 		}
 	}
 }


### PR DESCRIPTION
## :construction_worker: Purpose
The previous security update to the API implemented a custom `http.Server` object. This gives the ability to closure the server connection, which is something the previous usage of `gin.Engine` didn't allow.


## :rocket: Changes
When the context for the `ListenAndServer` function call is cancelled, execution and return `HTTP::Server::Close`


## :warning: Breaking Changes
None, probably fixed a small bug.

