### PR TITLE
Allow Pinning Of IPNS Hashes

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -528,6 +528,7 @@ func (api *API) setupRoutes() error {
 		public := ipns.Group("/public")
 		{
 			public.POST("/publish/details", api.publishToIPNSDetails)
+			public.POST("/pin", api.pinIPNSHash)
 		}
 		// private ipns routes
 		private := ipns.Group("/private")

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -528,6 +528,9 @@ func (api *API) setupRoutes() error {
 		public := ipns.Group("/public")
 		{
 			public.POST("/publish/details", api.publishToIPNSDetails)
+			// used to handle pinning of IPNS records on public ipfs
+			// this involves first resolving the record, parsing it
+			// and extracting the hash to pin
 			public.POST("/pin", api.pinIPNSHash)
 		}
 		// private ipns routes

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -35,7 +35,6 @@ const (
 
 var (
 	hash       = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
-	ipnsPath   = "/ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
 	authHeader string
 )
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	hash       = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
+	ipnsPath   = "ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
 	authHeader string
 )
 

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	hash       = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
-	ipnsPath   = "ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
+	ipnsPath   = "/ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
 	authHeader string
 )
 

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -218,7 +219,7 @@ func (api *API) pinIPNSHash(c *gin.Context) {
 	// this will likely need to wait for IPFS Cluster 0.8.0
 	shell := ipfsapi.NewShell(api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port)
 	if !shell.IsUp() {
-		api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(errors.New("node is not online"), eh.IPFSConnectionError)(c, http.StatusBadRequest)
 		return
 	}
 	hashToPin, err := shell.Resolve(forms["ipns_path"])

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
+
+	path "gx/ipfs/QmZErC2Ay6WuGi96CPg316PwitdwgLo6RxZRqVjJjRj2MR/go-path"
 
 	"github.com/RTradeLtd/Temporal/eh"
 	"github.com/RTradeLtd/Temporal/queue"
 	"github.com/RTradeLtd/Temporal/utils"
+	ipfsapi "github.com/RTradeLtd/go-ipfs-api"
 	gocid "github.com/ipfs/go-cid"
 
 	"github.com/gin-gonic/gin"
@@ -179,4 +183,76 @@ func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": records})
+}
+
+// PinIPNSHash is used to pin the content referenced by an IPNS record
+// only usable by public IPFS.
+// The processing logic is as follows:
+// 1) parse the path which will be /ipns/hash
+// 2) validate that it is a valid path
+// 3) resolve the cid referenced by the record
+// 4) pop the last segment of the path, which will be the hash we are looking to pin
+func (api *API) pinIPNSHash(c *gin.Context) {
+	username, err := GetAuthenticatedUserFromContext(c)
+	if err != nil {
+		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		return
+	}
+	forms := api.extractPostForms(c, "hold_time", "ipns_path")
+	if len(forms) == 0 {
+		return
+	}
+	parsedPath := path.FromString(forms["ipns_path"])
+	if err := parsedPath.IsValid(); err != nil {
+		Fail(c, err, http.StatusBadRequest)
+		return
+	}
+	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
+	if err != nil {
+		Fail(c, err)
+		return
+	}
+	// extract the hash to pin
+	// as an unfortunate work-around we need to establish a seperate shell for this
+	// TODO: come back to this and make it work without this janky work-around
+	// this will likely need to wait for IPFS Cluster 0.8.0
+	shell := ipfsapi.NewShell(api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port)
+	if !shell.IsUp() {
+		api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		return
+	}
+	hashToPin, err := shell.Resolve(forms["ipns_path"])
+	if err != nil {
+		api.LogError(err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
+		return
+	}
+	// extract the hash to pin by using the cid at the very end of the path
+	// if someone is passing in a multi-cid path like /ipfs/cidA/cidB/cidC
+	// IPFS will pin cidC, although most of our service will recognize this as a valid hash
+	// IPFS Cluster doesn't, so to keep consistency with the rest of our endpoints
+	// we should only operate on a bare cidC
+	hash := strings.Split(hashToPin, "/")[len(strings.Split(hashToPin, "/"))-1]
+	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
+	if err != nil {
+		api.LogError(err, eh.PinCostCalculationError)(c, http.StatusBadRequest)
+		return
+	}
+	if err := api.validateUserCredits(username, cost); err != nil {
+		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		return
+	}
+	ip := queue.IPFSPin{
+		CID:              hash,
+		NetworkName:      "public",
+		UserName:         username,
+		HoldTimeInMonths: holdTimeInt,
+		CreditCost:       cost,
+	}
+	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
+		api.LogError(err, eh.QueuePublishError)(c)
+		api.refundUserCredits(username, "pin", cost)
+		return
+	}
+	api.l.Infow("ipfs pin request sent to backend", "user", username)
+	Respond(c, http.StatusOK, gin.H{"response": "pin request sent to backend"})
 }

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	ipfsapi "github.com/RTradeLtd/go-ipfs-api"
+
 	"github.com/RTradeLtd/Temporal/mocks"
 	"github.com/RTradeLtd/config"
 	"github.com/RTradeLtd/database/models"
@@ -145,18 +147,34 @@ func Test_API_Routes_IPNS(t *testing.T) {
 	}
 
 	// test pinning of an ipns hash
-	// /api/v2/ipfs/public/pin
+	// for this we need to create a temporary ipns record
+	ipfsapi := ipfsapi.NewShell(api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port)
+	resp, err := ipfsapi.PublishWithDetails(hash, "self", time.Hour*24, time.Hour*24, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// /v2/ipfs/public/pin
 	apiResp = apiResponse{}
 	urlValues = url.Values{}
 	urlValues.Add("hold_time", "5")
-	urlValues.Add("ipns_path", ipnsPath)
+	urlValues.Add("ipns_path", resp.Name)
 	if err := sendRequest(
-		api, "POST", "/api/v2/ipns/public/pin", 200, nil, urlValues, &apiResp,
+		api, "POST", "/v2/ipns/public/pin", 200, nil, urlValues, &apiResp,
 	); err != nil {
 		t.Fatal(err)
 	}
 	// validate the response code
 	if apiResp.Code != 200 {
-		t.Fatal("bad api status code from  /api/v2/ipfs/public/pin")
+		t.Fatal("bad api status code from  /v2/ipfs/public/pin")
+	}
+	// /v2/ipfs/public/pin - bad path
+	apiResp = apiResponse{}
+	urlValues = url.Values{}
+	urlValues.Add("hold_time", "5")
+	urlValues.Add("ipns_path", "/not/a/real/path")
+	if err := sendRequest(
+		api, "POST", "/v2/ipns/public/pin", 400, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -187,4 +187,15 @@ func Test_API_Routes_IPNS(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	// /v2/ipfs/public/pin - invalid node connection
+	apiResp = apiResponse{}
+	urlValues = url.Values{}
+	urlValues.Add("hold_time", "5")
+	urlValues.Add("ipns_path", resp.Name)
+	api.cfg.IPFS.APIConnection.Host = "notarealhost"
+	if err := sendRequest(
+		api, "POST", "/v2/ipns/public/pin", 400, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -177,4 +177,14 @@ func Test_API_Routes_IPNS(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	// /v2/ipfs/public/pin - bad ipfs path
+	apiResp = apiResponse{}
+	urlValues = url.Values{}
+	urlValues.Add("hold_time", "5")
+	urlValues.Add("ipns_path", "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/real/path")
+	if err := sendRequest(
+		api, "POST", "/v2/ipns/public/pin", 400, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -151,7 +151,7 @@ func Test_API_Routes_IPNS(t *testing.T) {
 	urlValues.Add("hold_time", "5")
 	urlValues.Add("ipns_path", ipnsPath)
 	if err := sendRequest(
-		api, "POST", "/api/v2/ipns/public/pin/"+hash, 200, nil, urlValues, &apiResp,
+		api, "POST", "/api/v2/ipns/public/pin", 200, nil, urlValues, &apiResp,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -143,4 +143,20 @@ func Test_API_Routes_IPNS(t *testing.T) {
 	if len(*ipnsAPIResp.Response) == 0 {
 		t.Fatal("no records discovered")
 	}
+
+	// test pinning of an ipns hash
+	// /api/v2/ipfs/public/pin
+	apiResp = apiResponse{}
+	urlValues = url.Values{}
+	urlValues.Add("hold_time", "5")
+	urlValues.Add("ipns_path", ipnsPath)
+	if err := sendRequest(
+		api, "POST", "/api/v2/ipns/public/pin/"+hash, 200, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// validate the response code
+	if apiResp.Code != 200 {
+		t.Fatal("bad api status code from  /api/v2/ipfs/public/pin")
+	}
 }

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -6,13 +6,15 @@ import (
 	"net/http"
 	"strconv"
 
+	path "gx/ipfs/QmZErC2Ay6WuGi96CPg316PwitdwgLo6RxZRqVjJjRj2MR/go-path"
+
 	"github.com/RTradeLtd/Temporal/eh"
 	"github.com/RTradeLtd/Temporal/mini"
-	"github.com/RTradeLtd/Temporal/utils"
-	gocid "github.com/ipfs/go-cid"
-
 	"github.com/RTradeLtd/Temporal/queue"
+	"github.com/RTradeLtd/Temporal/utils"
+	ipfsapi "github.com/RTradeLtd/go-ipfs-api"
 	"github.com/gin-gonic/gin"
+	gocid "github.com/ipfs/go-cid"
 )
 
 // PinHashLocally is used to pin a hash to the local ipfs node
@@ -29,6 +31,77 @@ func (api *API) pinHashLocally(c *gin.Context) {
 	}
 	forms := api.extractPostForms(c, "hold_time")
 	if len(forms) == 0 {
+		return
+	}
+	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
+	if err != nil {
+		Fail(c, err)
+		return
+	}
+	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
+	if err != nil {
+		api.LogError(err, eh.PinCostCalculationError)(c, http.StatusBadRequest)
+		return
+	}
+	if err := api.validateUserCredits(username, cost); err != nil {
+		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		return
+	}
+	ip := queue.IPFSPin{
+		CID:              hash,
+		NetworkName:      "public",
+		UserName:         username,
+		HoldTimeInMonths: holdTimeInt,
+		CreditCost:       cost,
+	}
+	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
+		api.LogError(err, eh.QueuePublishError)(c)
+		api.refundUserCredits(username, "pin", cost)
+		return
+	}
+	api.l.Infow("ipfs pin request sent to backend", "user", username)
+	Respond(c, http.StatusOK, gin.H{"response": "pin request sent to backend"})
+}
+
+// PinIPNSHash is used to pin the content referenced by an IPNS record
+// only usable by public IPFS.
+// The processing logic is as follows:
+// 1) parse the path which will be /ipns/hash
+// 2) validate that it is a valid path
+// 3) resolve the cid referenced by the record
+// 4) pop the last segment of the path, which will be the hash we are looking to pin
+func (api *API) pinIPNSHash(c *gin.Context) {
+	username, err := GetAuthenticatedUserFromContext(c)
+	if err != nil {
+		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		return
+	}
+	forms := api.extractPostForms(c, "hold_time", "ipns_path")
+	if len(forms) == 0 {
+		return
+	}
+	parsedPath := path.FromString(forms["ipns_path"])
+	if err := parsedPath.IsValid(); err != nil {
+		Fail(c, err, http.StatusBadRequest)
+		return
+	}
+	// extract the hash to pin
+	// as an unfortunate work-around we need to establish a seperate shell for this
+	// TODO: come back to this and make it work without this janky work-around
+	shell := ipfsapi.NewShell(api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port)
+	if !shell.IsUp() {
+		api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		return
+	}
+	hashToPin, err := shell.Resolve(forms["ipns_path"])
+	if err != nil {
+		api.LogError(err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
+		return
+	}
+	// pop the last segment which is what we're after to pin
+	_, hash, err := path.FromString(hashToPin).PopLastSegment()
+	if err != nil {
+		api.LogError(err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)


### PR DESCRIPTION
## :construction_worker: Purpose
Previously we assumed all users would give us raw IPFS CIDs to pin. If someone gave us the IPNS hash that was referencing a CID, we would attempt to pin as if it were a CID, not as if it were an IPNS hash.

There is a pretty major overhaul to a package `ipfs/go-ipfs-files` which is required to not use this janky work around, however at the moment that version of IPFS files is incomptabile with the version of IPFS Cluster we are using. The next IPFS Cluster release will use the new `go-ipfs-files` package, so once that is out we'll get rid of this janky method.

## :rocket: Changes
Allow pinning of CIDs references by IPNS records by a dedicated API route which first resolves the IPNS record to extract the hash


## :warning: Breaking Changes
None

