### PR TITLE
Add X-Request-ID Header

### DIFF
--- a/api/middleware/cors.go
+++ b/api/middleware/cors.go
@@ -22,6 +22,6 @@ func CORSMiddleware(devMode bool) gin.HandlerFunc {
 	// allow the DELETE method, allowed methods are now
 	// DELETE GET POST PUT HEAD
 	corsConfig.AddAllowMethods("DELETE")
-	corsConfig.AddAllowHeaders("cache-control", "Authorization", "Content-Type")
+	corsConfig.AddAllowHeaders("cache-control", "Authorization", "Content-Type", "X-Request-ID")
 	return cors.New(corsConfig)
 }

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
@@ -12,6 +13,24 @@ import (
 	"github.com/RTradeLtd/database"
 	"github.com/jinzhu/gorm"
 )
+
+func TestRequestIDMiddleware(t *testing.T) {
+	testRecorder := httptest.NewRecorder()
+	_, engine := gin.CreateTestContext(testRecorder)
+	engine.Use(RequestID())
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine.GET("/foo", func(c *gin.Context) {
+		c.String(200, "hello")
+	})
+	engine.ServeHTTP(testRecorder, req)
+	if testRecorder.HeaderMap.Get("X-Request-ID") == "" {
+		t.Fatal("failed to set a request header")
+	}
+
+}
 
 func TestJwtMiddleware(t *testing.T) {
 	cfg, err := config.LoadConfig("../../testenv/config.json")

--- a/api/middleware/requestid.go
+++ b/api/middleware/requestid.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// RequestID is used to insert a randomly generated
+// uuid as a value to a X-Request-ID header
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Request-ID", uuid.New().String())
+		c.Next()
+	}
+}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -245,25 +245,25 @@ func new(cfg *config.TemporalConfig, router *gin.Engine, l *zap.SugaredLogger, l
 func (api *API) Close() {
 	// close queue resources
 	if err := api.queues.cluster.Close(); err != nil {
-		api.LogError(err, "failed to properly close cluster queue connection")
+		api.l.Error(err, "failed to properly close cluster queue connection")
 	}
 	if err := api.queues.database.Close(); err != nil {
-		api.LogError(err, "failed to properly close database queue connection")
+		api.l.Error(err, "failed to properly close database queue connection")
 	}
 	if err := api.queues.email.Close(); err != nil {
-		api.LogError(err, "failed to properly close email queue connection")
+		api.l.Error(err, "failed to properly close email queue connection")
 	}
 	if err := api.queues.file.Close(); err != nil {
-		api.LogError(err, "failed to properly close file queue connection")
+		api.l.Error(err, "failed to properly close file queue connection")
 	}
 	if err := api.queues.ipns.Close(); err != nil {
-		api.LogError(err, "failed to properly close ipns queue connection")
+		api.l.Error(err, "failed to properly close ipns queue connection")
 	}
 	if err := api.queues.key.Close(); err != nil {
-		api.LogError(err, "failed to properly close key queue connection")
+		api.l.Error(err, "failed to properly close key queue connection")
 	}
 	if err := api.queues.pin.Close(); err != nil {
-		api.LogError(err, "failed to properly close pin queue connection")
+		api.l.Error(err, "failed to properly close pin queue connection")
 	}
 }
 

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -345,6 +345,8 @@ func (api *API) setupRoutes() error {
 		middleware.NewSecWare(dev),
 		// cors middleware
 		middleware.CORSMiddleware(dev),
+		// request id middleware
+		middleware.RequestID(),
 		// stats middleware
 		stats.RequestStats())
 

--- a/api/v2/log.go
+++ b/api/v2/log.go
@@ -14,7 +14,7 @@ import (
 // with the given request to make it easier to debug user-submitted erros.
 func (api *API) LogError(c *gin.Context, err error, message string, fields ...interface{}) func(code ...int) {
 	// create base entry with the associated request id
-	logger := api.l.Named(c.GetHeader("X-Request-ID"))
+	logger := api.l.With("request-id", c.GetHeader("X-Request-ID"))
 
 	// write log
 	if fields != nil && len(fields)%2 == 0 {

--- a/api/v2/log.go
+++ b/api/v2/log.go
@@ -29,7 +29,7 @@ func (api *API) LogError(c *gin.Context, err error, message string, fields ...in
 
 	// return utility callback
 	if message == "" && err != nil {
-		return func(c *gin.Context, code ...int) { Fail(c, err, code...) }
+		return func(code ...int) { Fail(c, err, code...) }
 	}
-	return func(c *gin.Context, code ...int) { FailWithMessage(c, message, code...) }
+	return func(code ...int) { FailWithMessage(c, message, code...) }
 }

--- a/api/v2/log.go
+++ b/api/v2/log.go
@@ -9,9 +9,12 @@ import (
 // defaults to http.StatusInternalServerError. Fields is an optional set of
 // params provided in pairs, where the first of a pair is the key, and the second
 // is the value
-func (api *API) LogError(err error, message string, fields ...interface{}) func(c *gin.Context, code ...int) {
-	// create base entry
-	logger := api.l
+//
+// Passing in the initial gin.Context to LogError is used to extract the X-Request-ID associated
+// with the given request to make it easier to debug user-submitted erros.
+func (api *API) LogError(c *gin.Context, err error, message string, fields ...interface{}) func(c *gin.Context, code ...int) {
+	// create base entry with the associated request id
+	logger := api.l.Named(c.GetHeader("X-Request-ID"))
 
 	// write log
 	if fields != nil && len(fields)%2 == 0 {

--- a/api/v2/log.go
+++ b/api/v2/log.go
@@ -12,7 +12,7 @@ import (
 //
 // Passing in the initial gin.Context to LogError is used to extract the X-Request-ID associated
 // with the given request to make it easier to debug user-submitted erros.
-func (api *API) LogError(c *gin.Context, err error, message string, fields ...interface{}) func(c *gin.Context, code ...int) {
+func (api *API) LogError(c *gin.Context, err error, message string, fields ...interface{}) func(code ...int) {
 	// create base entry with the associated request id
 	logger := api.l.Named(c.GetHeader("X-Request-ID"))
 

--- a/api/v2/log.go
+++ b/api/v2/log.go
@@ -14,12 +14,11 @@ import (
 // with the given request to make it easier to debug user-submitted erros.
 func (api *API) LogError(c *gin.Context, err error, message string, fields ...interface{}) func(code ...int) {
 	// create base entry with the associated request id
-	logger := api.l.With("request-id", c.GetHeader("X-Request-ID"))
+	var logger = api.l.With("request-id", c.GetHeader("X-Request-ID"))
 
 	// write log
 	if fields != nil && len(fields)%2 == 0 {
-		fields = append(fields, "error", err.Error())
-		logger.Errorw(message, fields...)
+		logger.Errorw(message, append(fields, "error", err.Error())...)
 	} else {
 		logger.Errorw(message, "error", err.Error())
 	}

--- a/api/v2/log_test.go
+++ b/api/v2/log_test.go
@@ -41,9 +41,9 @@ func TestAPI_LogError(t *testing.T) {
 			r := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(r)
 			if tt.args.fields != nil {
-				api.LogError(tt.args.err, tt.args.message, tt.args.fields...)(c)
+				api.LogError(c, tt.args.err, tt.args.message, tt.args.fields...)(c)
 			} else {
-				api.LogError(tt.args.err, tt.args.message)(c)
+				api.LogError(c, tt.args.err, tt.args.message)(c)
 			}
 
 			// check log message and context

--- a/api/v2/log_test.go
+++ b/api/v2/log_test.go
@@ -36,11 +36,12 @@ func TestAPI_LogError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			observer, out := observer.New(zap.InfoLevel)
 			logger := zap.New(observer).Sugar()
-			api := API{l: logger, service: "test"}
+			r := httptest.NewRecorder()
+			c, e := gin.CreateTestContext(r)
+			api := API{l: logger, service: "test", r: e}
 
 			// log error and execute callback
-			r := httptest.NewRecorder()
-			c, _ := gin.CreateTestContext(r)
+			c.Request = httptest.NewRequest("GET", "/", nil)
 			if tt.args.fields != nil {
 				api.LogError(c, tt.args.err, tt.args.message, tt.args.fields...)(http.StatusBadRequest)
 			} else {

--- a/api/v2/log_test.go
+++ b/api/v2/log_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -41,9 +42,9 @@ func TestAPI_LogError(t *testing.T) {
 			r := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(r)
 			if tt.args.fields != nil {
-				api.LogError(c, tt.args.err, tt.args.message, tt.args.fields...)(c)
+				api.LogError(c, tt.args.err, tt.args.message, tt.args.fields...)(http.StatusBadRequest)
 			} else {
-				api.LogError(c, tt.args.err, tt.args.message)(c)
+				api.LogError(c, tt.args.err, tt.args.message)(http.StatusBadRequest)
 			}
 
 			// check log message and context

--- a/api/v2/routes_account.go
+++ b/api/v2/routes_account.go
@@ -17,7 +17,7 @@ import (
 func (api *API) getUserFromToken(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": username})
@@ -27,7 +27,7 @@ func (api *API) getUserFromToken(c *gin.Context) {
 func (api *API) verifyEmailAddress(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "token")
@@ -35,7 +35,7 @@ func (api *API) verifyEmailAddress(c *gin.Context) {
 		return
 	}
 	if _, err := api.um.ValidateEmailVerificationToken(username, forms["token"]); err != nil {
-		api.LogError(c, err, eh.EmailVerificationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.EmailVerificationError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "email verified"})
@@ -45,12 +45,12 @@ func (api *API) verifyEmailAddress(c *gin.Context) {
 func (api *API) getEmailVerificationToken(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	user, err := api.um.GenerateEmailVerificationToken(username)
 	if err != nil {
-		api.LogError(c, err, eh.EmailTokenGenerationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.EmailTokenGenerationError)(http.StatusBadRequest)
 		return
 	}
 	es := queue.EmailSend{
@@ -61,7 +61,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "Email verification token sent to email. Please check and follow instructions"})
@@ -71,7 +71,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 func (api *API) changeAccountPassword(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "old_password", "new_password")
@@ -82,11 +82,11 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 	forms["new_password"] = html.UnescapeString(forms["new_password"])
 	api.l.With("user", username).Info("password change requested")
 	if ok, err := api.um.ChangePassword(username, forms["old_password"], forms["new_password"]); err != nil {
-		api.LogError(c, err, eh.PasswordChangeError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PasswordChangeError)(http.StatusBadRequest)
 		return
 	} else if !ok {
 		err = fmt.Errorf("password changed failed for user %s to due an unspecified error", username)
-		api.LogError(c, err, eh.PasswordChangeError)(c)
+		api.LogError(c, err, eh.PasswordChangeError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("password changed",
@@ -106,13 +106,13 @@ func (api *API) registerUserAccount(c *gin.Context) {
 	if err != nil {
 		switch err.Error() {
 		case eh.DuplicateEmailError:
-			api.LogError(c, err, eh.DuplicateEmailError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.DuplicateEmailError)(http.StatusBadRequest)
 			return
 		case eh.DuplicateUserNameError:
-			api.LogError(c, err, eh.DuplicateUserNameError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.DuplicateUserNameError)(http.StatusBadRequest)
 			return
 		default:
-			api.LogError(c, err, eh.UserAccountCreationError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.UserAccountCreationError)(http.StatusBadRequest)
 			return
 		}
 	}
@@ -125,7 +125,7 @@ func (api *API) registerUserAccount(c *gin.Context) {
 func (api *API) createIPFSKey(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "key_type", "key_bits", "key_name")
@@ -143,7 +143,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	}
 	user, err := api.um.FindByUserName(username)
 	if err != nil {
-		api.LogError(c, err, eh.UserSearchError)(c, http.StatusNotFound)
+		api.LogError(c, err, eh.UserSearchError)(http.StatusNotFound)
 		return
 	}
 	var cost float64
@@ -155,16 +155,16 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		cost, err = utils.CalculateAPICallCost(forms["key_type"], false)
 	}
 	if err != nil {
-		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil && cost > 0 {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	keys, err := api.um.GetKeysForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.KeySearchError)(c, http.StatusNotFound)
+		api.LogError(c, err, eh.KeySearchError)(http.StatusNotFound)
 		api.refundUserCredits(username, "key", cost)
 		return
 	}
@@ -173,7 +173,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	for _, v := range keys["key_names"] {
 		if v == keyName {
 			err = fmt.Errorf("key with name already exists")
-			api.LogError(c, err, eh.DuplicateKeyCreationError)(c, http.StatusConflict)
+			api.LogError(c, err, eh.DuplicateKeyCreationError)(http.StatusConflict)
 			api.refundUserCredits(username, "key", cost)
 			return
 		}
@@ -192,7 +192,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		CreditCost:  cost,
 	}
 	if err = api.queues.key.PublishMessageWithExchange(key, queue.IpfsKeyExchange); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "key", cost)
 		return
 	}
@@ -204,12 +204,12 @@ func (api *API) createIPFSKey(c *gin.Context) {
 func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	keys, err := api.um.GetKeysForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.KeySearchError)(c)
+		api.LogError(c, err, eh.KeySearchError)(http.StatusBadRequest)
 		return
 	}
 	// if the user has no keys, fail with an error
@@ -226,12 +226,12 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 func (api *API) getCredits(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	credits, err := api.um.GetCreditsForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.CreditCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CreditCheckError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("credit check requested", "user", username)
@@ -242,12 +242,12 @@ func (api *API) getCredits(c *gin.Context) {
 func (api *API) forgotEmail(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	user, err := api.um.FindByUserName(username)
 	if err != nil {
-		api.LogError(c, err, eh.UserSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UserSearchError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": user.EmailAddress})
@@ -276,7 +276,7 @@ func (api *API) forgotUserName(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "username reminder sent account email"})
@@ -290,7 +290,7 @@ func (api *API) resetPassword(c *gin.Context) {
 	}
 	user, err := api.um.FindByEmail(forms["email_address"])
 	if err != nil {
-		api.LogError(c, err, eh.UserSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UserSearchError)(http.StatusBadRequest)
 		return
 	}
 	if !user.EmailEnabled {
@@ -299,7 +299,7 @@ func (api *API) resetPassword(c *gin.Context) {
 	}
 	newPass, err := api.um.ResetPassword(user.UserName)
 	if err != nil {
-		api.LogError(c, err, eh.PasswordResetError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PasswordResetError)(http.StatusBadRequest)
 		return
 	}
 	es := queue.EmailSend{
@@ -310,7 +310,7 @@ func (api *API) resetPassword(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "password reset, please check your email for a new password"})

--- a/api/v2/routes_account.go
+++ b/api/v2/routes_account.go
@@ -17,7 +17,7 @@ import (
 func (api *API) getUserFromToken(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": username})
@@ -27,7 +27,7 @@ func (api *API) getUserFromToken(c *gin.Context) {
 func (api *API) verifyEmailAddress(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "token")
@@ -35,7 +35,7 @@ func (api *API) verifyEmailAddress(c *gin.Context) {
 		return
 	}
 	if _, err := api.um.ValidateEmailVerificationToken(username, forms["token"]); err != nil {
-		api.LogError(err, eh.EmailVerificationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.EmailVerificationError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "email verified"})
@@ -45,12 +45,12 @@ func (api *API) verifyEmailAddress(c *gin.Context) {
 func (api *API) getEmailVerificationToken(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	user, err := api.um.GenerateEmailVerificationToken(username)
 	if err != nil {
-		api.LogError(err, eh.EmailTokenGenerationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.EmailTokenGenerationError)(c, http.StatusBadRequest)
 		return
 	}
 	es := queue.EmailSend{
@@ -61,7 +61,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "Email verification token sent to email. Please check and follow instructions"})
@@ -71,7 +71,7 @@ func (api *API) getEmailVerificationToken(c *gin.Context) {
 func (api *API) changeAccountPassword(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "old_password", "new_password")
@@ -82,11 +82,11 @@ func (api *API) changeAccountPassword(c *gin.Context) {
 	forms["new_password"] = html.UnescapeString(forms["new_password"])
 	api.l.With("user", username).Info("password change requested")
 	if ok, err := api.um.ChangePassword(username, forms["old_password"], forms["new_password"]); err != nil {
-		api.LogError(err, eh.PasswordChangeError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PasswordChangeError)(c, http.StatusBadRequest)
 		return
 	} else if !ok {
 		err = fmt.Errorf("password changed failed for user %s to due an unspecified error", username)
-		api.LogError(err, eh.PasswordChangeError)(c)
+		api.LogError(c, err, eh.PasswordChangeError)(c)
 		return
 	}
 	api.l.Infow("password changed",
@@ -106,13 +106,13 @@ func (api *API) registerUserAccount(c *gin.Context) {
 	if err != nil {
 		switch err.Error() {
 		case eh.DuplicateEmailError:
-			api.LogError(err, eh.DuplicateEmailError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.DuplicateEmailError)(c, http.StatusBadRequest)
 			return
 		case eh.DuplicateUserNameError:
-			api.LogError(err, eh.DuplicateUserNameError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.DuplicateUserNameError)(c, http.StatusBadRequest)
 			return
 		default:
-			api.LogError(err, eh.UserAccountCreationError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.UserAccountCreationError)(c, http.StatusBadRequest)
 			return
 		}
 	}
@@ -125,7 +125,7 @@ func (api *API) registerUserAccount(c *gin.Context) {
 func (api *API) createIPFSKey(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "key_type", "key_bits", "key_name")
@@ -143,7 +143,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	}
 	user, err := api.um.FindByUserName(username)
 	if err != nil {
-		api.LogError(err, eh.UserSearchError)(c, http.StatusNotFound)
+		api.LogError(c, err, eh.UserSearchError)(c, http.StatusNotFound)
 		return
 	}
 	var cost float64
@@ -155,16 +155,16 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		cost, err = utils.CalculateAPICallCost(forms["key_type"], false)
 	}
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil && cost > 0 {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	keys, err := api.um.GetKeysForUser(username)
 	if err != nil {
-		api.LogError(err, eh.KeySearchError)(c, http.StatusNotFound)
+		api.LogError(c, err, eh.KeySearchError)(c, http.StatusNotFound)
 		api.refundUserCredits(username, "key", cost)
 		return
 	}
@@ -173,7 +173,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 	for _, v := range keys["key_names"] {
 		if v == keyName {
 			err = fmt.Errorf("key with name already exists")
-			api.LogError(err, eh.DuplicateKeyCreationError)(c, http.StatusConflict)
+			api.LogError(c, err, eh.DuplicateKeyCreationError)(c, http.StatusConflict)
 			api.refundUserCredits(username, "key", cost)
 			return
 		}
@@ -192,7 +192,7 @@ func (api *API) createIPFSKey(c *gin.Context) {
 		CreditCost:  cost,
 	}
 	if err = api.queues.key.PublishMessageWithExchange(key, queue.IpfsKeyExchange); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		api.refundUserCredits(username, "key", cost)
 		return
 	}
@@ -204,12 +204,12 @@ func (api *API) createIPFSKey(c *gin.Context) {
 func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	keys, err := api.um.GetKeysForUser(username)
 	if err != nil {
-		api.LogError(err, eh.KeySearchError)(c)
+		api.LogError(c, err, eh.KeySearchError)(c)
 		return
 	}
 	// if the user has no keys, fail with an error
@@ -226,12 +226,12 @@ func (api *API) getIPFSKeyNamesForAuthUser(c *gin.Context) {
 func (api *API) getCredits(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	credits, err := api.um.GetCreditsForUser(username)
 	if err != nil {
-		api.LogError(err, eh.CreditCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CreditCheckError)(c, http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("credit check requested", "user", username)
@@ -242,12 +242,12 @@ func (api *API) getCredits(c *gin.Context) {
 func (api *API) forgotEmail(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	user, err := api.um.FindByUserName(username)
 	if err != nil {
-		api.LogError(err, eh.UserSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UserSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": user.EmailAddress})
@@ -276,7 +276,7 @@ func (api *API) forgotUserName(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "username reminder sent account email"})
@@ -290,7 +290,7 @@ func (api *API) resetPassword(c *gin.Context) {
 	}
 	user, err := api.um.FindByEmail(forms["email_address"])
 	if err != nil {
-		api.LogError(err, eh.UserSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UserSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	if !user.EmailEnabled {
@@ -299,7 +299,7 @@ func (api *API) resetPassword(c *gin.Context) {
 	}
 	newPass, err := api.um.ResetPassword(user.UserName)
 	if err != nil {
-		api.LogError(err, eh.PasswordResetError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PasswordResetError)(c, http.StatusBadRequest)
 		return
 	}
 	es := queue.EmailSend{
@@ -310,7 +310,7 @@ func (api *API) resetPassword(c *gin.Context) {
 		Emails:      []string{user.EmailAddress},
 	}
 	if err = api.queues.email.PublishMessage(es); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": "password reset, please check your email for a new password"})

--- a/api/v2/routes_database.go
+++ b/api/v2/routes_database.go
@@ -11,13 +11,13 @@ import (
 func (api *API) getUploadsForUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	// fetch all uploads for that address
 	uploads, err := api.upm.GetUploadsForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.UploadSearchError)(c, http.StatusInternalServerError)
+		api.LogError(c, err, eh.UploadSearchError)(http.StatusInternalServerError)
 		return
 	}
 	api.l.Info("specific uploads from database requested")
@@ -28,17 +28,17 @@ func (api *API) getUploadsForUser(c *gin.Context) {
 func (api *API) getUploadsByNetworkName(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	uploads, err := api.upm.FindUploadsByNetwork(networkName)
 	if err != nil {
-		api.LogError(c, err, eh.UploadSearchError)(c)
+		api.LogError(c, err, eh.UploadSearchError)(http.StatusInternalServerError)
 		return
 	}
 

--- a/api/v2/routes_database.go
+++ b/api/v2/routes_database.go
@@ -11,13 +11,13 @@ import (
 func (api *API) getUploadsForUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	// fetch all uploads for that address
 	uploads, err := api.upm.GetUploadsForUser(username)
 	if err != nil {
-		api.LogError(err, eh.UploadSearchError)(c, http.StatusInternalServerError)
+		api.LogError(c, err, eh.UploadSearchError)(c, http.StatusInternalServerError)
 		return
 	}
 	api.l.Info("specific uploads from database requested")
@@ -28,17 +28,17 @@ func (api *API) getUploadsForUser(c *gin.Context) {
 func (api *API) getUploadsByNetworkName(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	uploads, err := api.upm.FindUploadsByNetwork(networkName)
 	if err != nil {
-		api.LogError(err, eh.UploadSearchError)(c)
+		api.LogError(c, err, eh.UploadSearchError)(c)
 		return
 	}
 

--- a/api/v2/routes_frontend.go
+++ b/api/v2/routes_frontend.go
@@ -16,7 +16,7 @@ import (
 func (api *API) calculatePinCost(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -52,7 +52,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 func (api *API) calculateFileCost(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	file, err := c.FormFile("file")
@@ -90,12 +90,12 @@ func (api *API) calculateFileCost(c *gin.Context) {
 func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	uploads, err := api.ue.FindUploadsByUser(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.LogError(c, err, eh.UploadSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UploadSearchError)(http.StatusBadRequest)
 		return
 	}
 	if len(*uploads) == 0 {

--- a/api/v2/routes_frontend.go
+++ b/api/v2/routes_frontend.go
@@ -16,7 +16,7 @@ import (
 func (api *API) calculatePinCost(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -40,7 +40,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 	}
 	totalCost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, isPrivate)
 	if err != nil {
-		api.LogError(err, eh.PinCostCalculationError)
+		api.LogError(c, err, eh.PinCostCalculationError)
 		Fail(c, err)
 		return
 	}
@@ -52,7 +52,7 @@ func (api *API) calculatePinCost(c *gin.Context) {
 func (api *API) calculateFileCost(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	file, err := c.FormFile("file")
@@ -90,12 +90,12 @@ func (api *API) calculateFileCost(c *gin.Context) {
 func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	uploads, err := api.ue.FindUploadsByUser(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.LogError(err, eh.UploadSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.UploadSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	if len(*uploads) == 0 {

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -23,7 +23,7 @@ import (
 func (api *API) publishToIPNSDetails(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "hash", "life_time", "ttl", "key", "resolve")
@@ -36,22 +36,22 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 	}
 	cost, err := utils.CalculateAPICallCost("ipns", false)
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	ownsKey, err := api.um.CheckIfKeyOwnedByUser(username, forms["key"])
 	if err != nil {
-		api.LogError(err, eh.KeySearchError)(c)
+		api.LogError(c, err, eh.KeySearchError)(c)
 		api.refundUserCredits(username, "ipns", cost)
 		return
 	}
 	if !ownsKey {
 		err = fmt.Errorf("user %s attempted to generate IPFS entry with unowned key", username)
-		api.LogError(err, eh.KeyUseError)(c)
+		api.LogError(c, err, eh.KeyUseError)(c)
 		api.refundUserCredits(username, "ipns", cost)
 		return
 	}
@@ -84,7 +84,7 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 		CreditCost:  cost,
 	}
 	if err = api.queues.ipns.PublishMessage(ie); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		api.refundUserCredits(username, "ipns", cost)
 		return
 	}
@@ -96,7 +96,7 @@ func (api *API) publishToIPNSDetails(c *gin.Context) {
 func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "network_name", "hash", "life_time", "ttl", "key", "resolve")
@@ -105,15 +105,15 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 	}
 	cost, err := utils.CalculateAPICallCost("ipns", true)
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	if _, err := gocid.Decode(forms["hash"]); err != nil {
@@ -122,12 +122,12 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 	}
 	ownsKey, err := api.um.CheckIfKeyOwnedByUser(username, forms["key"])
 	if err != nil {
-		api.LogError(err, eh.KeySearchError)(c)
+		api.LogError(c, err, eh.KeySearchError)(c)
 		return
 	}
 	if !ownsKey {
 		err = fmt.Errorf("unauthorized access to key by user %s", username)
-		api.LogError(err, eh.KeyUseError)(c)
+		api.LogError(c, err, eh.KeyUseError)(c)
 		return
 	}
 	resolve, err := strconv.ParseBool(forms["resolve"])
@@ -159,7 +159,7 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:  cost,
 	}
 	if err = api.queues.ipns.PublishMessage(ipnsUpdate); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("private ipns entry creation request sent to backend", "user", username)
@@ -170,12 +170,12 @@ func (api *API) publishDetailedIPNSToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	records, err := api.im.FindByUserName(username)
 	if err != nil {
-		api.LogError(err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	// check if records is nil, or no entries. For len we must dereference first
@@ -196,7 +196,7 @@ func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 func (api *API) pinIPNSHash(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "hold_time", "ipns_path")
@@ -219,12 +219,12 @@ func (api *API) pinIPNSHash(c *gin.Context) {
 	// this will likely need to wait for IPFS Cluster 0.8.0
 	shell := ipfsapi.NewShell(api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port)
 	if !shell.IsUp() {
-		api.LogError(errors.New("node is not online"), eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(c, errors.New("node is not online"), eh.IPFSConnectionError)(c, http.StatusBadRequest)
 		return
 	}
 	hashToPin, err := shell.Resolve(forms["ipns_path"])
 	if err != nil {
-		api.LogError(err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IpnsRecordSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	// extract the hash to pin by using the cid at the very end of the path
@@ -235,11 +235,11 @@ func (api *API) pinIPNSHash(c *gin.Context) {
 	hash := strings.Split(hashToPin, "/")[len(strings.Split(hashToPin, "/"))-1]
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
 	if err != nil {
-		api.LogError(err, eh.PinCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PinCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	ip := queue.IPFSPin{
@@ -250,7 +250,7 @@ func (api *API) pinIPNSHash(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c)
+		api.LogError(c, err, eh.QueuePublishError)(c)
 		api.refundUserCredits(username, "pin", cost)
 		return
 	}

--- a/api/v2/routes_lens.go
+++ b/api/v2/routes_lens.go
@@ -36,7 +36,7 @@ func (api *API) submitIndexRequest(c *gin.Context) {
 		Reindex:    c.PostForm("reindex") == "yes",
 	})
 	if err != nil {
-		api.LogError(err, eh.FailedToIndexError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.FailedToIndexError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{
@@ -63,7 +63,7 @@ func (api *API) submitSearchRequest(c *gin.Context) {
 	})
 	if err != nil {
 		fmt.Println(err)
-		api.LogError(err, eh.FailedToSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.FailedToSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	if len(resp.GetObjects()) == 0 {

--- a/api/v2/routes_lens.go
+++ b/api/v2/routes_lens.go
@@ -36,7 +36,7 @@ func (api *API) submitIndexRequest(c *gin.Context) {
 		Reindex:    c.PostForm("reindex") == "yes",
 	})
 	if err != nil {
-		api.LogError(c, err, eh.FailedToIndexError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.FailedToIndexError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{
@@ -63,7 +63,7 @@ func (api *API) submitSearchRequest(c *gin.Context) {
 	})
 	if err != nil {
 		fmt.Println(err)
-		api.LogError(c, err, eh.FailedToSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.FailedToSearchError)(http.StatusBadRequest)
 		return
 	}
 	if len(resp.GetObjects()) == 0 {

--- a/api/v2/routes_payment.go
+++ b/api/v2/routes_payment.go
@@ -23,7 +23,7 @@ import (
 func (api *API) ConfirmPayment(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "payment_number", "tx_hash")
@@ -36,12 +36,12 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 		return
 	}
 	if _, err := api.pm.FindPaymentByNumber(username, paymentNumberInt); err != nil {
-		api.LogError(err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	payment, err := api.pm.UpdatePaymentTxHash(username, forms["tx_hash"], paymentNumberInt)
 	if err != nil {
-		api.LogError(err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	paymentConfirmation := queue.PaymentConfirmation{
@@ -49,7 +49,7 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 		PaymentNumber: paymentNumberInt,
 	}
 	if err = api.queues.payConfirm.PublishMessage(paymentConfirmation); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": payment})
@@ -59,7 +59,7 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "payment_type", "sender_address", "credit_value")
@@ -84,13 +84,13 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	// get the current value of a single (ie, 1.0 eth) unit of currency of the given payment type
 	usdValueFloat, err := api.getUSDValue(paymentType)
 	if err != nil {
-		api.LogError(err, eh.CmcCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CmcCheckError)(c, http.StatusBadRequest)
 		return
 	}
 	// get the number of the current payment we are processing
 	paymentNumber, err := api.pm.GetLatestPaymentNumber(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.LogError(err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	// convert the credits the user wants to buy from string to float
@@ -126,7 +126,7 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	// using the returned values, we have the information needed to send a call to the smart contract
 	resp, err := api.signer.GetSignedMessage(context.Background(), &signRequest)
 	if err != nil {
-		api.LogError(err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	paymentNumberString := fmt.Sprintf("%s-%s", username, strconv.FormatInt(paymentNumber, 10))
@@ -140,12 +140,12 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 		paymentType,
 		username,
 	); err != nil {
-		api.LogError(err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	vUint, err := strconv.ParseUint(resp.GetV(), 10, 64)
 	if err != nil {
-		api.LogError(err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	formattedH := fmt.Sprintf("0x%s", resp.GetH())
@@ -170,7 +170,7 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 func (api *API) CreateDashPayment(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "credit_value")
@@ -190,7 +190,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 	chargeAmountFloat := creditValueFloat / usdValueFloat
 	paymentNumber, err := api.pm.GetLatestPaymentNumber(username)
 	if err != nil {
-		api.LogError(err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	// as we require tx hashes be unique in the database
@@ -208,11 +208,11 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		},
 	)
 	if err != nil {
-		api.LogError(err, eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
 		return
 	}
 	if response.Error != "" {
-		api.LogError(errors.New(response.Error), eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
+		api.LogError(c, errors.New(response.Error), eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
 		return
 	}
 	if _, err = api.pm.NewPayment(
@@ -225,7 +225,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		"dash",
 		username,
 	); err != nil {
-		api.LogError(err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
 		return
 	}
 	confirmation := &queue.DashPaymenConfirmation{
@@ -234,7 +234,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		PaymentNumber:    paymentNumber,
 	}
 	if err = api.queues.dash.PublishMessage(confirmation); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	type pay struct {
@@ -268,7 +268,7 @@ func (api *API) GetDepositAddress(c *gin.Context) {
 	paymentType := c.Param("type")
 	address, err := api.getDepositAddress(paymentType)
 	if err != nil {
-		api.LogError(err, eh.InvalidPaymentTypeError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.InvalidPaymentTypeError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": address})

--- a/api/v2/routes_payment.go
+++ b/api/v2/routes_payment.go
@@ -23,7 +23,7 @@ import (
 func (api *API) ConfirmPayment(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "payment_number", "tx_hash")
@@ -36,12 +36,12 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 		return
 	}
 	if _, err := api.pm.FindPaymentByNumber(username, paymentNumberInt); err != nil {
-		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(http.StatusBadRequest)
 		return
 	}
 	payment, err := api.pm.UpdatePaymentTxHash(username, forms["tx_hash"], paymentNumberInt)
 	if err != nil {
-		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(http.StatusBadRequest)
 		return
 	}
 	paymentConfirmation := queue.PaymentConfirmation{
@@ -49,7 +49,7 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 		PaymentNumber: paymentNumberInt,
 	}
 	if err = api.queues.payConfirm.PublishMessage(paymentConfirmation); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": payment})
@@ -59,7 +59,7 @@ func (api *API) ConfirmPayment(c *gin.Context) {
 func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "payment_type", "sender_address", "credit_value")
@@ -84,13 +84,13 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	// get the current value of a single (ie, 1.0 eth) unit of currency of the given payment type
 	usdValueFloat, err := api.getUSDValue(paymentType)
 	if err != nil {
-		api.LogError(c, err, eh.CmcCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CmcCheckError)(http.StatusBadRequest)
 		return
 	}
 	// get the number of the current payment we are processing
 	paymentNumber, err := api.pm.GetLatestPaymentNumber(username)
 	if err != nil && err != gorm.ErrRecordNotFound {
-		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(http.StatusBadRequest)
 		return
 	}
 	// convert the credits the user wants to buy from string to float
@@ -126,7 +126,7 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 	// using the returned values, we have the information needed to send a call to the smart contract
 	resp, err := api.signer.GetSignedMessage(context.Background(), &signRequest)
 	if err != nil {
-		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(http.StatusBadRequest)
 		return
 	}
 	paymentNumberString := fmt.Sprintf("%s-%s", username, strconv.FormatInt(paymentNumber, 10))
@@ -140,12 +140,12 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 		paymentType,
 		username,
 	); err != nil {
-		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(http.StatusBadRequest)
 		return
 	}
 	vUint, err := strconv.ParseUint(resp.GetV(), 10, 64)
 	if err != nil {
-		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(http.StatusBadRequest)
 		return
 	}
 	formattedH := fmt.Sprintf("0x%s", resp.GetH())
@@ -170,7 +170,7 @@ func (api *API) RequestSignedPaymentMessage(c *gin.Context) {
 func (api *API) CreateDashPayment(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "credit_value")
@@ -190,7 +190,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 	chargeAmountFloat := creditValueFloat / usdValueFloat
 	paymentNumber, err := api.pm.GetLatestPaymentNumber(username)
 	if err != nil {
-		api.LogError(c, err, eh.PaymentSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PaymentSearchError)(http.StatusBadRequest)
 		return
 	}
 	// as we require tx hashes be unique in the database
@@ -208,11 +208,11 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		},
 	)
 	if err != nil {
-		api.LogError(c, err, eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.ChainRiderAPICallError)(http.StatusBadRequest)
 		return
 	}
 	if response.Error != "" {
-		api.LogError(c, errors.New(response.Error), eh.ChainRiderAPICallError)(c, http.StatusBadRequest)
+		api.LogError(c, errors.New(response.Error), eh.ChainRiderAPICallError)(http.StatusBadRequest)
 		return
 	}
 	if _, err = api.pm.NewPayment(
@@ -225,7 +225,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		"dash",
 		username,
 	); err != nil {
-		api.LogError(c, err, err.Error())(c, http.StatusBadRequest)
+		api.LogError(c, err, err.Error())(http.StatusBadRequest)
 		return
 	}
 	confirmation := &queue.DashPaymenConfirmation{
@@ -234,7 +234,7 @@ func (api *API) CreateDashPayment(c *gin.Context) {
 		PaymentNumber:    paymentNumber,
 	}
 	if err = api.queues.dash.PublishMessage(confirmation); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	type pay struct {
@@ -268,7 +268,7 @@ func (api *API) GetDepositAddress(c *gin.Context) {
 	paymentType := c.Param("type")
 	address, err := api.getDepositAddress(paymentType)
 	if err != nil {
-		api.LogError(c, err, eh.InvalidPaymentTypeError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.InvalidPaymentTypeError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": address})

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -23,7 +23,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 	}
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "hold_time")
@@ -37,11 +37,11 @@ func (api *API) pinHashLocally(c *gin.Context) {
 	}
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
 	if err != nil {
-		api.LogError(c, err, eh.PinCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PinCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	ip := queue.IPFSPin{
@@ -52,7 +52,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "pin", cost)
 		return
 	}
@@ -66,7 +66,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	logger := api.l.With("user", username)
@@ -80,7 +80,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	endpoint := fmt.Sprintf("%s:%s", api.cfg.MINIO.Connection.IP, api.cfg.MINIO.Connection.Port)
 	miniManager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, false)
 	if err != nil {
-		api.LogError(c, err, eh.MinioConnectionError)(c)
+		api.LogError(c, err, eh.MinioConnectionError)(http.StatusBadRequest)
 		return
 	}
 	fileHandler, err := c.FormFile("file")
@@ -99,14 +99,14 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeInt, fileHandler.Size, false)
 	if err = api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	logger.Debug("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
 		api.LogError(c, err, eh.FileOpenError,
-			"user", username)(c)
+			"user", username)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -121,7 +121,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 			EncryptPassphrase: html.UnescapeString(c.PostForm("passphrase")),
 		}); err != nil {
 		api.LogError(c, err, eh.MinioPutError,
-			"user", username)(c)
+			"user", username)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -141,7 +141,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 	}
 	if err = api.queues.file.PublishMessage(ifp); err != nil {
 		api.LogError(c, err, eh.QueuePublishError,
-			"user", username)(c)
+			"user", username)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -154,7 +154,7 @@ func (api *API) addFileLocallyAdvanced(c *gin.Context) {
 func (api *API) addFileLocally(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "hold_time")
@@ -178,14 +178,14 @@ func (api *API) addFileLocally(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeinMonthsInt, fileHandler.Size, false)
 	if err = api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	// open the file
 	api.l.Debug("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
-		api.LogError(c, err, eh.FileOpenError)(c)
+		api.LogError(c, err, eh.FileOpenError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -193,7 +193,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 	api.l.Debug("initializing manager")
 	// initialize a connection to the local ipfs node
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -201,7 +201,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 	api.l.Debug("adding file...")
 	resp, err := api.ipfs.Add(openFile)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSAddError)(c)
+		api.LogError(c, err, eh.IPFSAddError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "file", cost)
 		return
 	}
@@ -213,7 +213,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 		HoldTimeInMonths: holdTimeinMonthsInt,
 		CreditCost:       0,
 	}, queue.PinExchange); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	// construct a message to rabbitmq to upad the database
@@ -225,7 +225,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 		CreditCost:       0,
 	}
 	if err = api.queues.database.PublishMessage(dfa); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("simple ipfs file upload processed", "user", username)
@@ -236,7 +236,7 @@ func (api *API) addFileLocally(c *gin.Context) {
 func (api *API) ipfsPubSubPublish(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	topic := c.Param("topic")
@@ -246,20 +246,20 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 	}
 	cost, err := utils.CalculateAPICallCost("pubsub", false)
 	if err != nil {
-		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "pubsub", cost)
 		return
 	}
 	if err = api.ipfs.PubSubPublish(topic, forms["message"]); err != nil {
-		api.LogError(c, err, eh.IPFSPubSubPublishError)(c)
+		api.LogError(c, err, eh.IPFSPubSubPublishError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "pubsub", cost)
 		return
 	}
@@ -272,7 +272,7 @@ func (api *API) ipfsPubSubPublish(c *gin.Context) {
 func (api *API) getObjectStatForIpfs(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	key := c.Param("key")
@@ -300,7 +300,7 @@ func (api *API) getDagObject(c *gin.Context) {
 	}
 	var out interface{}
 	if err := api.ipfs.DagGet(hash, &out); err != nil {
-		api.LogError(c, err, eh.IPFSDagGetError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSDagGetError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": out})

--- a/api/v2/routes_rtfs_cluster.go
+++ b/api/v2/routes_rtfs_cluster.go
@@ -16,7 +16,7 @@ import (
 func (api *API) pinHashToCluster(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -35,11 +35,11 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 	}
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	ipfsClusterPin := queue.IPFSClusterPin{
@@ -50,7 +50,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.cluster.PublishMessage(ipfsClusterPin); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		api.refundUserCredits(username, "cluster-pin", cost)
 		return
 	}

--- a/api/v2/routes_rtfs_cluster.go
+++ b/api/v2/routes_rtfs_cluster.go
@@ -16,7 +16,7 @@ import (
 func (api *API) pinHashToCluster(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -35,11 +35,11 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 	}
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, api.ipfs, false)
 	if err != nil {
-		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	ipfsClusterPin := queue.IPFSClusterPin{
@@ -50,7 +50,7 @@ func (api *API) pinHashToCluster(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.cluster.PublishMessage(ipfsClusterPin); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "cluster-pin", cost)
 		return
 	}

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -17,7 +17,7 @@ import (
 func (api *API) createIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -43,14 +43,14 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 
 	network, err := api.nm.CreateHostedPrivateNetwork(networkName, swarmKey, bPeers, users)
 	if err != nil {
-		api.LogError(err, eh.NetworkCreationError)(c)
+		api.LogError(c, err, eh.NetworkCreationError)(c)
 		return
 	}
 	logger.With("db_id", network.ID).Info("database entry created")
 	if len(users) > 0 {
 		for _, v := range users {
 			if err := api.um.AddIPFSNetworkForUser(v, networkName); err != nil && err.Error() != "network already configured for user" {
-				api.LogError(err, eh.NetworkCreationError)(c)
+				api.LogError(c, err, eh.NetworkCreationError)(c)
 				return
 			}
 			api.l.With("user", v).Info("network added to user)")
@@ -62,7 +62,7 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 		Network: networkName,
 	})
 	if err != nil {
-		api.LogError(err, "failed to start private network",
+		api.LogError(c, err, "failed to start private network",
 			"network_name", networkName,
 		)(c)
 		return
@@ -84,7 +84,7 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -98,7 +98,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	// verify access to the requested network
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 		return
 	}
 	var found bool
@@ -117,7 +117,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	}
 	if _, err := api.orch.StartNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(err, "failed to start network")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to start network")(c, http.StatusBadRequest)
 		return
 	}
 	logger.Info("network started")
@@ -132,7 +132,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -146,7 +146,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	// retrieve authorized networks to check if person has access
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	var found bool
@@ -166,7 +166,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	fmt.Println(1)
 	if _, err := api.orch.StopNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(err, "failed to stop network")(c)
+		api.LogError(c, err, "failed to stop network")(c)
 		return
 	}
 	logger.Info("network stopped")
@@ -181,7 +181,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -194,7 +194,7 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	// retrieve authorized networks to check if person has access
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	var found bool
@@ -215,25 +215,25 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	// tell orchestrator to remove the network, and all of its data
 	if _, err = api.orch.RemoveNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(err, "failed to remove network assets")(c)
+		api.LogError(c, err, "failed to remove network assets")(c)
 		return
 	}
 	// search for the network to get list of users who have access
 	// this allows us to search through the user table, and remove the network from it
 	network, err := api.nm.GetNetworkByName(networkName)
 	if err != nil {
-		api.LogError(err, eh.NetworkSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NetworkSearchError)(c, http.StatusBadRequest)
 		return
 	}
 	// remove network from database
 	if err = api.nm.Delete(networkName); err != nil {
-		api.LogError(err, "failed to remove network from database")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to remove network from database")(c, http.StatusBadRequest)
 		return
 	}
 	// remove network from users authorized networks
 	for _, v := range network.Users {
 		if err = api.um.RemoveIPFSNetworkForUser(v, networkName); err != nil {
-			api.LogError(err, "failed to remove network from users")(c, http.StatusBadRequest)
+			api.LogError(c, err, "failed to remove network from users")(c, http.StatusBadRequest)
 			return
 		}
 	}
@@ -250,13 +250,13 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	netName := c.Param("name")
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	var found bool
@@ -274,7 +274,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	logger.Info("private ipfs network by name requested")
 	net, err := api.nm.GetNetworkByName(netName)
 	if err != nil {
-		api.LogError(err, eh.NetworkSearchError)(c)
+		api.LogError(c, err, eh.NetworkSearchError)(c)
 		return
 	}
 
@@ -283,7 +283,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 		logger.Info("retrieving additional stats from orchestrator")
 		stats, err := api.orch.NetworkStats(c, &ipfs_orchestrator.NetworkRequest{Network: netName})
 		if err != nil {
-			api.LogError(err, eh.NetworkSearchError)(c)
+			api.LogError(c, err, eh.NetworkSearchError)(c)
 			return
 		}
 
@@ -303,12 +303,12 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 func (api *API) getAuthorizedPrivateNetworks(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -17,7 +17,7 @@ import (
 func (api *API) createIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -43,14 +43,14 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 
 	network, err := api.nm.CreateHostedPrivateNetwork(networkName, swarmKey, bPeers, users)
 	if err != nil {
-		api.LogError(c, err, eh.NetworkCreationError)(c)
+		api.LogError(c, err, eh.NetworkCreationError)(http.StatusBadRequest)
 		return
 	}
 	logger.With("db_id", network.ID).Info("database entry created")
 	if len(users) > 0 {
 		for _, v := range users {
 			if err := api.um.AddIPFSNetworkForUser(v, networkName); err != nil && err.Error() != "network already configured for user" {
-				api.LogError(c, err, eh.NetworkCreationError)(c)
+				api.LogError(c, err, eh.NetworkCreationError)(http.StatusBadRequest)
 				return
 			}
 			api.l.With("user", v).Info("network added to user)")
@@ -64,7 +64,7 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 	if err != nil {
 		api.LogError(c, err, "failed to start private network",
 			"network_name", networkName,
-		)(c)
+		)(http.StatusBadRequest)
 		return
 	}
 	api.l.With("response", resp).Info("network node started")
@@ -84,7 +84,7 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -98,7 +98,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	// verify access to the requested network
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	var found bool
@@ -117,7 +117,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 	}
 	if _, err := api.orch.StartNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(c, err, "failed to start network")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to start network")(http.StatusBadRequest)
 		return
 	}
 	logger.Info("network started")
@@ -132,7 +132,7 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -146,7 +146,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	// retrieve authorized networks to check if person has access
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	var found bool
@@ -166,7 +166,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 	fmt.Println(1)
 	if _, err := api.orch.StopNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(c, err, "failed to stop network")(c)
+		api.LogError(c, err, "failed to stop network")(http.StatusBadRequest)
 		return
 	}
 	logger.Info("network stopped")
@@ -181,7 +181,7 @@ func (api *API) stopIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName, exists := c.GetPostForm("network_name")
@@ -194,7 +194,7 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	// retrieve authorized networks to check if person has access
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	var found bool
@@ -215,25 +215,25 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 	// tell orchestrator to remove the network, and all of its data
 	if _, err = api.orch.RemoveNetwork(c, &ipfs_orchestrator.NetworkRequest{
 		Network: networkName}); err != nil {
-		api.LogError(c, err, "failed to remove network assets")(c)
+		api.LogError(c, err, "failed to remove network assets")(http.StatusBadRequest)
 		return
 	}
 	// search for the network to get list of users who have access
 	// this allows us to search through the user table, and remove the network from it
 	network, err := api.nm.GetNetworkByName(networkName)
 	if err != nil {
-		api.LogError(c, err, eh.NetworkSearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NetworkSearchError)(http.StatusBadRequest)
 		return
 	}
 	// remove network from database
 	if err = api.nm.Delete(networkName); err != nil {
-		api.LogError(c, err, "failed to remove network from database")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to remove network from database")(http.StatusBadRequest)
 		return
 	}
 	// remove network from users authorized networks
 	for _, v := range network.Users {
 		if err = api.um.RemoveIPFSNetworkForUser(v, networkName); err != nil {
-			api.LogError(c, err, "failed to remove network from users")(c, http.StatusBadRequest)
+			api.LogError(c, err, "failed to remove network from users")(http.StatusBadRequest)
 			return
 		}
 	}
@@ -250,13 +250,13 @@ func (api *API) removeIPFSPrivateNetwork(c *gin.Context) {
 func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	netName := c.Param("name")
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	var found bool
@@ -274,7 +274,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 	logger.Info("private ipfs network by name requested")
 	net, err := api.nm.GetNetworkByName(netName)
 	if err != nil {
-		api.LogError(c, err, eh.NetworkSearchError)(c)
+		api.LogError(c, err, eh.NetworkSearchError)(http.StatusBadRequest)
 		return
 	}
 
@@ -283,7 +283,7 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 		logger.Info("retrieving additional stats from orchestrator")
 		stats, err := api.orch.NetworkStats(c, &ipfs_orchestrator.NetworkRequest{Network: netName})
 		if err != nil {
-			api.LogError(c, err, eh.NetworkSearchError)(c)
+			api.LogError(c, err, eh.NetworkSearchError)(http.StatusBadRequest)
 			return
 		}
 
@@ -303,12 +303,12 @@ func (api *API) getIPFSPrivateNetworkByName(c *gin.Context) {
 func (api *API) getAuthorizedPrivateNetworks(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networks, err := api.um.GetPrivateIPFSNetworksForUser(username)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 

--- a/api/v2/routes_rtfsp_usage.go
+++ b/api/v2/routes_rtfsp_usage.go
@@ -23,7 +23,7 @@ import (
 func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -36,18 +36,18 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	if err = CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	url, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(c, err, eh.APIURLCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 		return
 	}
 	manager, err := rtfs.NewManager(url, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
@@ -57,11 +57,11 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	}
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, manager, true)
 	if err != nil {
-		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	ip := queue.IPFSPin{
@@ -72,7 +72,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "private-pin", cost)
 		return
 	}
@@ -84,7 +84,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "network_name", "hold_time")
@@ -92,7 +92,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
@@ -120,7 +120,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeInt, fileHandler.Size, true)
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	api.l.Debug("opening file")
@@ -173,7 +173,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "network_name", "hold_time")
@@ -193,12 +193,12 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(c, err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 		return
 	}
 	ipfsManager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	fmt.Println("fetching file")
@@ -215,18 +215,18 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeInt, fileHandler.Size, true)
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	file, err := fileHandler.Open()
 	if err != nil {
-		api.LogError(c, err, eh.FileOpenError)(c)
+		api.LogError(c, err, eh.FileOpenError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "private-file", cost)
 		return
 	}
 	resp, err := ipfsManager.Add(file)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSAddError)(c)
+		api.LogError(c, err, eh.IPFSAddError)(http.StatusBadRequest)
 		api.refundUserCredits(username, "private-file", cost)
 		return
 	}
@@ -238,7 +238,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       0,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(pin, queue.PinExchange); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	fmt.Println("file uploaded")
@@ -250,7 +250,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       0,
 	}
 	if err = api.queues.database.PublishMessage(dfa); err != nil {
-		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("simple private ipfs file upload processed", "user", username)
@@ -261,7 +261,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	topic := c.Param("topic")
@@ -270,31 +270,31 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	cost, err := utils.CalculateAPICallCost("pubsub", true)
 	if err != nil {
-		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(http.StatusPaymentRequired)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(c, err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 		return
 	}
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	if err = manager.PubSubPublish(topic, forms["message"]); err != nil {
-		api.LogError(c, err, eh.IPFSPubSubPublishError)(c)
+		api.LogError(c, err, eh.IPFSPubSubPublishError)(http.StatusBadRequest)
 		return
 	}
 
@@ -307,7 +307,7 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	key := c.Param("hash")
@@ -317,25 +317,25 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(c, err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 		return
 	}
 
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	stats, err := manager.Stat(key)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSObjectStatError)(c)
+		api.LogError(c, err, eh.IPFSObjectStatError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("private ipfs object stat requested", "user", username)
@@ -346,7 +346,7 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -356,23 +356,23 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(c, err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 		return
 	}
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	present, err := manager.CheckPin(hash)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSPinParseError)(c)
+		api.LogError(c, err, eh.IPFSPinParseError)(http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("private ipfs pin check requested", "user", username)
@@ -388,27 +388,27 @@ func (api *API) getDagObjectForHostedIPFSNetwork(c *gin.Context) {
 	}
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	apiURL, err := api.nm.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
 	im, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 		return
 	}
 	var out interface{}
 	if err := im.DagGet(hash, &out); err != nil {
-		api.LogError(c, err, eh.IPFSDagGetError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSDagGetError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": out})

--- a/api/v2/routes_rtfsp_usage.go
+++ b/api/v2/routes_rtfsp_usage.go
@@ -23,7 +23,7 @@ import (
 func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -36,18 +36,18 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	if err = CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	url, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(err, eh.APIURLCheckError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.APIURLCheckError)(c, http.StatusBadRequest)
 		return
 	}
 	manager, err := rtfs.NewManager(url, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
 		return
 	}
 	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
@@ -57,11 +57,11 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 	}
 	cost, err := utils.CalculatePinCost(hash, holdTimeInt, manager, true)
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	ip := queue.IPFSPin{
@@ -72,7 +72,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       cost,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(ip, queue.PinExchange); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c)
+		api.LogError(c, err, eh.QueuePublishError)(c)
 		api.refundUserCredits(username, "private-pin", cost)
 		return
 	}
@@ -84,7 +84,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "network_name", "hold_time")
@@ -92,7 +92,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 		return
 	}
 	holdTimeInt, err := strconv.ParseInt(forms["hold_time"], 10, 64)
@@ -105,7 +105,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	endpoint := fmt.Sprintf("%s:%s", api.cfg.MINIO.Connection.IP, api.cfg.MINIO.Connection.Port)
 	miniManager, err := mini.NewMinioManager(endpoint, accessKey, secretKey, false)
 	if err != nil {
-		api.LogError(err, eh.MinioConnectionError)
+		api.LogError(c, err, eh.MinioConnectionError)
 		Fail(c, err)
 		return
 	}
@@ -120,13 +120,13 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeInt, fileHandler.Size, true)
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	api.l.Debug("opening file")
 	openFile, err := fileHandler.Open()
 	if err != nil {
-		api.LogError(err, eh.FileOpenError)
+		api.LogError(c, err, eh.FileOpenError)
 		api.refundUserCredits(username, "private-file", cost)
 		Fail(c, err)
 		return
@@ -141,7 +141,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 		Bucket:            FilesUploadBucket,
 		EncryptPassphrase: html.UnescapeString(c.PostForm("passphrase")),
 	}); err != nil {
-		api.LogError(err, eh.MinioPutError)
+		api.LogError(c, err, eh.MinioPutError)
 		api.refundUserCredits(username, "private-file", cost)
 		Fail(c, err)
 		return
@@ -160,7 +160,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 	}
 	api.l.Debugf("%s stored in minio", objectName)
 	if err = api.queues.file.PublishMessage(ifp); err != nil {
-		api.LogError(err, eh.QueuePublishError)
+		api.LogError(c, err, eh.QueuePublishError)
 		api.refundUserCredits(username, "private-file", cost)
 		Fail(c, err)
 		return
@@ -173,7 +173,7 @@ func (api *API) addFileToHostedIPFSNetworkAdvanced(c *gin.Context) {
 func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "network_name", "hold_time")
@@ -181,7 +181,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)
 		Fail(c, err)
 		return
 	}
@@ -193,12 +193,12 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(c)
 		return
 	}
 	ipfsManager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(c)
 		return
 	}
 	fmt.Println("fetching file")
@@ -215,18 +215,18 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 	}
 	cost := utils.CalculateFileCost(holdTimeInt, fileHandler.Size, true)
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	file, err := fileHandler.Open()
 	if err != nil {
-		api.LogError(err, eh.FileOpenError)(c)
+		api.LogError(c, err, eh.FileOpenError)(c)
 		api.refundUserCredits(username, "private-file", cost)
 		return
 	}
 	resp, err := ipfsManager.Add(file)
 	if err != nil {
-		api.LogError(err, eh.IPFSAddError)(c)
+		api.LogError(c, err, eh.IPFSAddError)(c)
 		api.refundUserCredits(username, "private-file", cost)
 		return
 	}
@@ -238,7 +238,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       0,
 	}
 	if err = api.queues.pin.PublishMessageWithExchange(pin, queue.PinExchange); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	fmt.Println("file uploaded")
@@ -250,7 +250,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		CreditCost:       0,
 	}
 	if err = api.queues.database.PublishMessage(dfa); err != nil {
-		api.LogError(err, eh.QueuePublishError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.QueuePublishError)(c, http.StatusBadRequest)
 		return
 	}
 	api.l.Infow("simple private ipfs file upload processed", "user", username)
@@ -261,7 +261,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	topic := c.Param("topic")
@@ -270,31 +270,31 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 		return
 	}
 	if err := CheckAccessForPrivateNetwork(username, forms["network_name"], api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	cost, err := utils.CalculateAPICallCost("pubsub", true)
 	if err != nil {
-		api.LogError(err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.CallCostCalculationError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateUserCredits(username, cost); err != nil {
-		api.LogError(err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
+		api.LogError(c, err, eh.InvalidBalanceError)(c, http.StatusPaymentRequired)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(forms["network_name"])
 	if err != nil {
-		api.LogError(err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(c)
 		return
 	}
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(c)
 		return
 	}
 	if err = manager.PubSubPublish(topic, forms["message"]); err != nil {
-		api.LogError(err, eh.IPFSPubSubPublishError)(c)
+		api.LogError(c, err, eh.IPFSPubSubPublishError)(c)
 		return
 	}
 
@@ -307,7 +307,7 @@ func (api *API) ipfsPubSubPublishToHostedIPFSNetwork(c *gin.Context) {
 func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	key := c.Param("hash")
@@ -317,25 +317,25 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(c)
 		return
 	}
 
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(c)
 		return
 	}
 	stats, err := manager.Stat(key)
 	if err != nil {
-		api.LogError(err, eh.IPFSObjectStatError)(c)
+		api.LogError(c, err, eh.IPFSObjectStatError)(c)
 		return
 	}
 	api.l.Infow("private ipfs object stat requested", "user", username)
@@ -346,7 +346,7 @@ func (api *API) getObjectStatForIpfsForHostedIPFSNetwork(c *gin.Context) {
 func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	hash := c.Param("hash")
@@ -356,23 +356,23 @@ func (api *API) checkLocalNodeForPinForHostedIPFSNetwork(c *gin.Context) {
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	im := models.NewHostedIPFSNetworkManager(api.dbm.DB)
 	apiURL, err := im.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(err, eh.APIURLCheckError)(c)
+		api.LogError(c, err, eh.APIURLCheckError)(c)
 		return
 	}
 	manager, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c)
+		api.LogError(c, err, eh.IPFSConnectionError)(c)
 		return
 	}
 	present, err := manager.CheckPin(hash)
 	if err != nil {
-		api.LogError(err, eh.IPFSPinParseError)(c)
+		api.LogError(c, err, eh.IPFSPinParseError)(c)
 		return
 	}
 	api.l.Infow("private ipfs pin check requested", "user", username)
@@ -388,27 +388,27 @@ func (api *API) getDagObjectForHostedIPFSNetwork(c *gin.Context) {
 	}
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	networkName := c.Param("networkName")
 	if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 		return
 	}
 	apiURL, err := api.nm.GetAPIURLByName(networkName)
 	if err != nil {
-		api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 		return
 	}
 	im, err := rtfs.NewManager(apiURL, nil, time.Minute*10)
 	if err != nil {
-		api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
 		return
 	}
 	var out interface{}
 	if err := im.DagGet(hash, &out); err != nil {
-		api.LogError(err, eh.IPFSDagGetError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.IPFSDagGetError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": out})

--- a/api/v2/routes_utils.go
+++ b/api/v2/routes_utils.go
@@ -28,7 +28,7 @@ func (api *API) SystemsCheck(c *gin.Context) {
 func (api *API) beamContent(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "source_network", "destination_network", "content_hash")
@@ -41,12 +41,12 @@ func (api *API) beamContent(c *gin.Context) {
 		source = api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port
 	} else {
 		if err := CheckAccessForPrivateNetwork(username, forms["source_network"], api.dbm.DB); err != nil {
-			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 			return
 		}
 		url, err := api.nm.GetAPIURLByName(forms["source_network"])
 		if err != nil {
-			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 			return
 		}
 		source = url
@@ -56,12 +56,12 @@ func (api *API) beamContent(c *gin.Context) {
 		dest = api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port
 	} else {
 		if err := CheckAccessForPrivateNetwork(username, forms["destination_network"], api.dbm.DB); err != nil {
-			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 			return
 		}
 		url, err := api.nm.GetAPIURLByName(forms["destination_network"])
 		if err != nil {
-			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 			return
 		}
 		dest = url
@@ -70,19 +70,19 @@ func (api *API) beamContent(c *gin.Context) {
 		// connect to the source network
 		net1Conn, err := rtfs.NewManager(source, nil, time.Minute*10)
 		if err != nil {
-			api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 			return
 		}
 		// encrypt the file file
 		data, err := net1Conn.Cat(forms["content_hash"])
 		if err != nil {
-			api.LogError(c, err, eh.IPFSCatError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSCatError)(http.StatusBadRequest)
 			return
 		}
 		// re-add the encrypted content to the source network
 		newCid, err := net1Conn.Add(bytes.NewReader(data))
 		if err != nil {
-			api.LogError(c, err, eh.IPFSAddError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSAddError)(http.StatusBadRequest)
 			return
 		}
 		// update the content hash to beam
@@ -91,12 +91,12 @@ func (api *API) beamContent(c *gin.Context) {
 	// create our dual network connection
 	laserBeam, err := beam.NewLaser(source, dest)
 	if err != nil {
-		api.LogError(c, err, "failed to initialize laser beam")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to initialize laser beam")(http.StatusBadRequest)
 		return
 	}
 	// initiate the content transfer
 	if err := laserBeam.BeamFromSource(forms["content_hash"]); err != nil {
-		api.LogError(c, err, "failed to tranfer content")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to tranfer content")(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": gin.H{"status": "content transferred", "content_hash": forms["content_hash"]}})
@@ -106,28 +106,28 @@ func (api *API) beamContent(c *gin.Context) {
 func (api *API) exportKey(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	keyName := c.Param("name")
 	owns, err := api.um.CheckIfKeyOwnedByUser(username, keyName)
 	if err != nil {
-		api.LogError(c, err, eh.KeySearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeySearchError)(http.StatusBadRequest)
 		return
 	}
 	if !owns {
-		api.LogError(c, errors.New(eh.KeyUseError), eh.KeyUseError)(c, http.StatusBadRequest)
+		api.LogError(c, errors.New(eh.KeyUseError), eh.KeyUseError)(http.StatusBadRequest)
 		return
 	}
 
 	resp, err := api.keys.GetPrivateKey(context.Background(), &pb.KeyGet{Name: keyName})
 	if err != nil {
-		api.LogError(c, err, eh.KeyExportError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeyExportError)(http.StatusBadRequest)
 		return
 	}
 	phrase, err := mnemonics.ToPhrase(resp.PrivateKey, mnemonics.English)
 	if err != nil {
-		api.LogError(c, err, eh.KeyExportError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeyExportError)(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": phrase})
@@ -137,7 +137,7 @@ func (api *API) exportKey(c *gin.Context) {
 func (api *API) downloadContentHash(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	// get the content hash that is to be downloaded
@@ -156,19 +156,19 @@ func (api *API) downloadContentHash(c *gin.Context) {
 	} else if networkName != "public" {
 		// validate user access to network
 		if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-			api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 			return
 		}
 		// retrieve api url
 		apiURL, err := api.nm.GetAPIURLByName(networkName)
 		if err != nil {
-			api.LogError(c, err, eh.APIURLCheckError)(c)
+			api.LogError(c, err, eh.APIURLCheckError)(http.StatusBadRequest)
 			return
 		}
 		// initialize our connection to IPFS
 		manager, err = rtfs.NewManager(apiURL, nil, time.Minute*10)
 		if err != nil {
-			api.LogError(c, err, eh.IPFSConnectionError)(c)
+			api.LogError(c, err, eh.IPFSConnectionError)(http.StatusBadRequest)
 			return
 		}
 	}
@@ -185,14 +185,14 @@ func (api *API) downloadContentHash(c *gin.Context) {
 	// read the contents of the file
 	contents, err := manager.Cat(contentHash)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSCatError)(c)
+		api.LogError(c, err, eh.IPFSCatError)(http.StatusBadRequest)
 		return
 	}
 	reader := bytes.NewReader(contents)
 	// get the size of hte file in bytes
 	stats, err := manager.Stat(contentHash)
 	if err != nil {
-		api.LogError(c, err, eh.IPFSObjectStatError)(c)
+		api.LogError(c, err, eh.IPFSObjectStatError)(http.StatusBadRequest)
 		return
 	}
 

--- a/api/v2/routes_utils.go
+++ b/api/v2/routes_utils.go
@@ -28,7 +28,7 @@ func (api *API) SystemsCheck(c *gin.Context) {
 func (api *API) beamContent(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	forms := api.extractPostForms(c, "source_network", "destination_network", "content_hash")
@@ -41,12 +41,12 @@ func (api *API) beamContent(c *gin.Context) {
 		source = api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port
 	} else {
 		if err := CheckAccessForPrivateNetwork(username, forms["source_network"], api.dbm.DB); err != nil {
-			api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 			return
 		}
 		url, err := api.nm.GetAPIURLByName(forms["source_network"])
 		if err != nil {
-			api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 			return
 		}
 		source = url
@@ -56,12 +56,12 @@ func (api *API) beamContent(c *gin.Context) {
 		dest = api.cfg.IPFS.APIConnection.Host + ":" + api.cfg.IPFS.APIConnection.Port
 	} else {
 		if err := CheckAccessForPrivateNetwork(username, forms["destination_network"], api.dbm.DB); err != nil {
-			api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 			return
 		}
 		url, err := api.nm.GetAPIURLByName(forms["destination_network"])
 		if err != nil {
-			api.LogError(err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(c, http.StatusBadRequest)
 			return
 		}
 		dest = url
@@ -70,19 +70,19 @@ func (api *API) beamContent(c *gin.Context) {
 		// connect to the source network
 		net1Conn, err := rtfs.NewManager(source, nil, time.Minute*10)
 		if err != nil {
-			api.LogError(err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSConnectionError)(c, http.StatusBadRequest)
 			return
 		}
 		// encrypt the file file
 		data, err := net1Conn.Cat(forms["content_hash"])
 		if err != nil {
-			api.LogError(err, eh.IPFSCatError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSCatError)(c, http.StatusBadRequest)
 			return
 		}
 		// re-add the encrypted content to the source network
 		newCid, err := net1Conn.Add(bytes.NewReader(data))
 		if err != nil {
-			api.LogError(err, eh.IPFSAddError)(c, http.StatusBadRequest)
+			api.LogError(c, err, eh.IPFSAddError)(c, http.StatusBadRequest)
 			return
 		}
 		// update the content hash to beam
@@ -91,12 +91,12 @@ func (api *API) beamContent(c *gin.Context) {
 	// create our dual network connection
 	laserBeam, err := beam.NewLaser(source, dest)
 	if err != nil {
-		api.LogError(err, "failed to initialize laser beam")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to initialize laser beam")(c, http.StatusBadRequest)
 		return
 	}
 	// initiate the content transfer
 	if err := laserBeam.BeamFromSource(forms["content_hash"]); err != nil {
-		api.LogError(err, "failed to tranfer content")(c, http.StatusBadRequest)
+		api.LogError(c, err, "failed to tranfer content")(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": gin.H{"status": "content transferred", "content_hash": forms["content_hash"]}})
@@ -106,28 +106,28 @@ func (api *API) beamContent(c *gin.Context) {
 func (api *API) exportKey(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	keyName := c.Param("name")
 	owns, err := api.um.CheckIfKeyOwnedByUser(username, keyName)
 	if err != nil {
-		api.LogError(err, eh.KeySearchError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeySearchError)(c, http.StatusBadRequest)
 		return
 	}
 	if !owns {
-		api.LogError(errors.New(eh.KeyUseError), eh.KeyUseError)(c, http.StatusBadRequest)
+		api.LogError(c, errors.New(eh.KeyUseError), eh.KeyUseError)(c, http.StatusBadRequest)
 		return
 	}
 
 	resp, err := api.keys.GetPrivateKey(context.Background(), &pb.KeyGet{Name: keyName})
 	if err != nil {
-		api.LogError(err, eh.KeyExportError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeyExportError)(c, http.StatusBadRequest)
 		return
 	}
 	phrase, err := mnemonics.ToPhrase(resp.PrivateKey, mnemonics.English)
 	if err != nil {
-		api.LogError(err, eh.KeyExportError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.KeyExportError)(c, http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": phrase})
@@ -137,7 +137,7 @@ func (api *API) exportKey(c *gin.Context) {
 func (api *API) downloadContentHash(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	// get the content hash that is to be downloaded
@@ -156,19 +156,19 @@ func (api *API) downloadContentHash(c *gin.Context) {
 	} else if networkName != "public" {
 		// validate user access to network
 		if err := CheckAccessForPrivateNetwork(username, networkName, api.dbm.DB); err != nil {
-			api.LogError(err, eh.PrivateNetworkAccessError)(c)
+			api.LogError(c, err, eh.PrivateNetworkAccessError)(c)
 			return
 		}
 		// retrieve api url
 		apiURL, err := api.nm.GetAPIURLByName(networkName)
 		if err != nil {
-			api.LogError(err, eh.APIURLCheckError)(c)
+			api.LogError(c, err, eh.APIURLCheckError)(c)
 			return
 		}
 		// initialize our connection to IPFS
 		manager, err = rtfs.NewManager(apiURL, nil, time.Minute*10)
 		if err != nil {
-			api.LogError(err, eh.IPFSConnectionError)(c)
+			api.LogError(c, err, eh.IPFSConnectionError)(c)
 			return
 		}
 	}
@@ -185,14 +185,14 @@ func (api *API) downloadContentHash(c *gin.Context) {
 	// read the contents of the file
 	contents, err := manager.Cat(contentHash)
 	if err != nil {
-		api.LogError(err, eh.IPFSCatError)(c)
+		api.LogError(c, err, eh.IPFSCatError)(c)
 		return
 	}
 	reader := bytes.NewReader(contents)
 	// get the size of hte file in bytes
 	stats, err := manager.Stat(contentHash)
 	if err != nil {
-		api.LogError(err, eh.IPFSObjectStatError)(c)
+		api.LogError(c, err, eh.IPFSObjectStatError)(c)
 		return
 	}
 

--- a/api/v2/stats.go
+++ b/api/v2/stats.go
@@ -11,7 +11,7 @@ import (
 func (api *API) getStats(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
 	if err := api.validateAdminRequest(username); err != nil {

--- a/api/v2/stats.go
+++ b/api/v2/stats.go
@@ -11,7 +11,7 @@ import (
 func (api *API) getStats(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
-		api.LogError(err, eh.NoAPITokenError)(c, http.StatusBadRequest)
+		api.LogError(c, err, eh.NoAPITokenError)(c, http.StatusBadRequest)
 		return
 	}
 	if err := api.validateAdminRequest(username); err != nil {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -920,7 +920,8 @@ func TestQueue_IPFSPin_Failure_RabbitMQ(t *testing.T) {
 		t.Fatal("failed to properly set exchange name on consumer")
 	}
 	cfg.RabbitMQ.URL = "notarealurl"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal("expected error")
@@ -949,7 +950,8 @@ func TestQueue_IPFSPin_Failure_LogFile(t *testing.T) {
 		t.Fatal("failed to properly set exchange name on consumer")
 	}
 	cfg.LogDir = "/root/toor"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal("expected error")
@@ -975,7 +977,8 @@ func TestQueue_IPFSFile_Failure_RTFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.IPFS.APIConnection.Host = "notarealip"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal("expected error")
@@ -1001,7 +1004,8 @@ func TestQueue_IPFSFile_Failure_LogDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.LogDir = "/root/toor"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal("expected error")
@@ -1027,7 +1031,8 @@ func TestQueue_IPFSFile_Failure_RabbitMQ(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.RabbitMQ.URL = "notarealip"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal("expected error")
@@ -1053,7 +1058,8 @@ func TestQueue_IPNSEntry_Failure_Krab(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg.Endpoints.Krab.TLS.CertPath = "/root/toor"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	// we don't need time-out since this test will automatically fail
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if err = qmConsumer.ConsumeMessages(ctx, &sync.WaitGroup{}, db, cfg); err == nil {
 		t.Fatal(err)


### PR DESCRIPTION
## :construction_worker: Purpose
Associates a randomly generated `X-Request-Header` to all requests. Anytime an error is logged, the `X-Request-ID` value is logged with the error message to make it easier to troubleshoot issues.


## :rocket: Changes
`X-Request-ID` header inserted with every request, and logged when errors occur

## :warning: Breaking Changes
None

