### PR TITLE
TEM-195: Queue Resiliency

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -318,55 +318,55 @@ func (api *API) ListenAndServe(ctx context.Context, addr string, tlsConfig *TLSC
 		case <-ctx.Done():
 			return server.Close()
 		case msg := <-api.queues.cluster.ErrCh:
-			qmCluster, err := api.handleQueueError(msg, api.cfg, queue.IpfsClusterPinQueue, true)
+			qmCluster, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.IpfsClusterPinQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.cluster = qmCluster
 		case msg := <-api.queues.dash.ErrCh:
-			qmDash, err := api.handleQueueError(msg, api.cfg, queue.DashPaymentConfirmationQueue, true)
+			qmDash, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.DashPaymentConfirmationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.dash = qmDash
 		case msg := <-api.queues.database.ErrCh:
-			qmDatabase, err := api.handleQueueError(msg, api.cfg, queue.DatabaseFileAddQueue, true)
+			qmDatabase, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.DatabaseFileAddQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.database = qmDatabase
 		case msg := <-api.queues.email.ErrCh:
-			qmEmail, err := api.handleQueueError(msg, api.cfg, queue.EmailSendQueue, true)
+			qmEmail, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.EmailSendQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.email = qmEmail
 		case msg := <-api.queues.file.ErrCh:
-			qmFile, err := api.handleQueueError(msg, api.cfg, queue.IpfsFileQueue, true)
+			qmFile, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.IpfsFileQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.file = qmFile
 		case msg := <-api.queues.ipns.ErrCh:
-			qmIpns, err := api.handleQueueError(msg, api.cfg, queue.IpnsEntryQueue, true)
+			qmIpns, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.IpnsEntryQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.ipns = qmIpns
 		case msg := <-api.queues.key.ErrCh:
-			qmKey, err := api.handleQueueError(msg, api.cfg, queue.IpfsKeyCreationQueue, true)
+			qmKey, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.IpfsKeyCreationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.key = qmKey
 		case msg := <-api.queues.payConfirm.ErrCh:
-			qmPay, err := api.handleQueueError(msg, api.cfg, queue.PaymentConfirmationQueue, true)
+			qmPay, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.PaymentConfirmationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.payConfirm = qmPay
 		case msg := <-api.queues.pin.ErrCh:
-			qmPin, err := api.handleQueueError(msg, api.cfg, queue.IpfsPinQueue, true)
+			qmPin, err := api.handleQueueError(msg, api.cfg.RabbitMQ.URL, queue.IpfsPinQueue, true)
 			if err != nil {
 				return server.Close()
 			}
@@ -624,12 +624,12 @@ func (api *API) setupRoutes() error {
 }
 
 // HandleQueueError is used to handle queue connectivity issues requiring us to re-connect
-func (api *API) handleQueueError(amqpErr *amqp.Error, cfg *config.TemporalConfig, queueType queue.Queue, publish bool) (*queue.Manager, error) {
+func (api *API) handleQueueError(amqpErr *amqp.Error, rabbitMQURL string, queueType queue.Queue, publish bool) (*queue.Manager, error) {
 	api.l.Errorw(
 		"a protocol connection error stopping rabbitmq was received",
 		"queue", queueType.String(),
 		"error", amqpErr.Error())
-	qManager, err := queue.New(queueType, cfg.RabbitMQ.URL, publish, api.l)
+	qManager, err := queue.New(queueType, rabbitMQURL, publish, api.l)
 	if err != nil {
 		api.l.Errorw(
 			"failed to re-establish queue process, exiting",

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/streadway/amqp"
+
 	"github.com/RTradeLtd/Temporal/log"
 	"github.com/RTradeLtd/Temporal/rtfscluster"
 	"go.uber.org/zap"
@@ -316,128 +318,56 @@ func (api *API) ListenAndServe(ctx context.Context, addr string, tlsConfig *TLSC
 		case <-ctx.Done():
 			return server.Close()
 		case msg := <-api.queues.cluster.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "cluster-pin",
-				"error", msg.Error())
-			qmCluster, err := queue.New(queue.IpfsClusterPinQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmCluster, err := api.handleQueueError(msg, api.cfg, queue.IpfsClusterPinQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "cluster-pin",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.cluster = qmCluster
 		case msg := <-api.queues.dash.ErrChannel:
-			api.l.Errorw(
-				"a protocol conection error stopping rabbitmq was received",
-				"queue", "dash-payment",
-				"error", msg.Error())
-			qmDash, err := queue.New(queue.DashPaymentConfirmationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmDash, err := api.handleQueueError(msg, api.cfg, queue.DashPaymentConfirmationQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue proces, exiting",
-					"queue", "dash-payment",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.dash = qmDash
 		case msg := <-api.queues.database.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "database-file-add",
-				"error", msg.Error())
-			qmDatabase, err := queue.New(queue.DatabaseFileAddQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmDatabase, err := api.handleQueueError(msg, api.cfg, queue.DatabaseFileAddQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "database-file-add",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.database = qmDatabase
 		case msg := <-api.queues.email.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "email-send",
-				"error", msg.Error())
-			qmEmail, err := queue.New(queue.EmailSendQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmEmail, err := api.handleQueueError(msg, api.cfg, queue.EmailSendQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "email-send",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.email = qmEmail
 		case msg := <-api.queues.file.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "ipfs-file",
-				"error", msg.Error())
-			qmFile, err := queue.New(queue.IpfsFileQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmFile, err := api.handleQueueError(msg, api.cfg, queue.IpfsFileQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "ipfs-file",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.file = qmFile
 		case msg := <-api.queues.ipns.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "ipns-entry",
-				"error", msg.Error())
-			qmIpns, err := queue.New(queue.IpnsEntryQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmIpns, err := api.handleQueueError(msg, api.cfg, queue.IpnsEntryQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "ipns-entry",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.ipns = qmIpns
 		case msg := <-api.queues.key.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "key-creation",
-				"error", msg.Error())
-			qmKey, err := queue.New(queue.IpfsKeyCreationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmKey, err := api.handleQueueError(msg, api.cfg, queue.IpfsKeyCreationQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "key-creation",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.key = qmKey
 		case msg := <-api.queues.payConfirm.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "pay-confirm",
-				"error", msg.Error())
-			qmPay, err := queue.New(queue.PaymentConfirmationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmPay, err := api.handleQueueError(msg, api.cfg, queue.PaymentConfirmationQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "pay-confirm",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.payConfirm = qmPay
 		case msg := <-api.queues.pin.ErrChannel:
-			api.l.Errorw(
-				"a protocol connection error stopping rabbitmq was received",
-				"queue", "ipfs-pin",
-				"error", msg.Error())
-			qmPin, err := queue.New(queue.IpfsPinQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			qmPin, err := api.handleQueueError(msg, api.cfg, queue.IpfsPinQueue, true)
 			if err != nil {
-				api.l.Errorw(
-					"failed to re-establish queue process, exiting",
-					"queue", "ipfs-pin",
-					"error", err.Error())
 				return server.Close()
 			}
 			api.queues.pin = qmPin
@@ -691,4 +621,24 @@ func (api *API) setupRoutes() error {
 
 	api.l.Info("Routes initialized")
 	return nil
+}
+
+// HandleQueueError is used to handle queue connectivity issues requiring us to re-connect
+func (api *API) handleQueueError(amqpErr *amqp.Error, cfg *config.TemporalConfig, queueType queue.Queue, publish bool) (*queue.Manager, error) {
+	api.l.Errorw(
+		"a protocol connection error stopping rabbitmq was received",
+		"queue", queueType.String(),
+		"error", amqpErr.Error())
+	qManager, err := queue.New(queueType, cfg.RabbitMQ.URL, publish, api.l)
+	if err != nil {
+		api.l.Errorw(
+			"failed to re-establish queue process, exiting",
+			"queue", queueType.String(),
+			"error", err.Error())
+		return nil, err
+	} else {
+		api.l.Warnw(
+			"successfully re-established queue connection", "queue", queueType.String())
+	}
+	return qManager, nil
 }

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -315,6 +315,132 @@ func (api *API) ListenAndServe(ctx context.Context, addr string, tlsConfig *TLSC
 			return err
 		case <-ctx.Done():
 			return server.Close()
+		case msg := <-api.queues.cluster.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "cluster-pin",
+				"error", msg.Error())
+			qmCluster, err := queue.New(queue.IpfsClusterPinQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "cluster-pin",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.cluster = qmCluster
+		case msg := <-api.queues.dash.ErrChannel:
+			api.l.Errorw(
+				"a protocol conection error stopping rabbitmq was received",
+				"queue", "dash-payment",
+				"error", msg.Error())
+			qmDash, err := queue.New(queue.DashPaymentConfirmationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue proces, exiting",
+					"queue", "dash-payment",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.dash = qmDash
+		case msg := <-api.queues.database.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "database-file-add",
+				"error", msg.Error())
+			qmDatabase, err := queue.New(queue.DatabaseFileAddQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "database-file-add",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.database = qmDatabase
+		case msg := <-api.queues.email.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "email-send",
+				"error", msg.Error())
+			qmEmail, err := queue.New(queue.EmailSendQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "email-send",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.email = qmEmail
+		case msg := <-api.queues.file.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "ipfs-file",
+				"error", msg.Error())
+			qmFile, err := queue.New(queue.IpfsFileQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "ipfs-file",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.file = qmFile
+		case msg := <-api.queues.ipns.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "ipns-entry",
+				"error", msg.Error())
+			qmIpns, err := queue.New(queue.IpnsEntryQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "ipns-entry",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.ipns = qmIpns
+		case msg := <-api.queues.key.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "key-creation",
+				"error", msg.Error())
+			qmKey, err := queue.New(queue.IpfsKeyCreationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "key-creation",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.key = qmKey
+		case msg := <-api.queues.payConfirm.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "pay-confirm",
+				"error", msg.Error())
+			qmPay, err := queue.New(queue.PaymentConfirmationQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "pay-confirm",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.payConfirm = qmPay
+		case msg := <-api.queues.pin.ErrChannel:
+			api.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"queue", "ipfs-pin",
+				"error", msg.Error())
+			qmPin, err := queue.New(queue.IpfsPinQueue, api.cfg.RabbitMQ.URL, true, api.l)
+			if err != nil {
+				api.l.Errorw(
+					"failed to re-establish queue process, exiting",
+					"queue", "ipfs-pin",
+					"error", err.Error())
+				return server.Close()
+			}
+			api.queues.pin = qmPin
 		}
 	}
 }

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -636,9 +636,8 @@ func (api *API) handleQueueError(amqpErr *amqp.Error, cfg *config.TemporalConfig
 			"queue", queueType.String(),
 			"error", err.Error())
 		return nil, err
-	} else {
-		api.l.Warnw(
-			"successfully re-established queue connection", "queue", queueType.String())
 	}
+	api.l.Warnw(
+		"successfully re-established queue connection", "queue", queueType.String())
 	return qManager, nil
 }

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -317,55 +317,55 @@ func (api *API) ListenAndServe(ctx context.Context, addr string, tlsConfig *TLSC
 			return err
 		case <-ctx.Done():
 			return server.Close()
-		case msg := <-api.queues.cluster.ErrChannel:
+		case msg := <-api.queues.cluster.ErrCh:
 			qmCluster, err := api.handleQueueError(msg, api.cfg, queue.IpfsClusterPinQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.cluster = qmCluster
-		case msg := <-api.queues.dash.ErrChannel:
+		case msg := <-api.queues.dash.ErrCh:
 			qmDash, err := api.handleQueueError(msg, api.cfg, queue.DashPaymentConfirmationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.dash = qmDash
-		case msg := <-api.queues.database.ErrChannel:
+		case msg := <-api.queues.database.ErrCh:
 			qmDatabase, err := api.handleQueueError(msg, api.cfg, queue.DatabaseFileAddQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.database = qmDatabase
-		case msg := <-api.queues.email.ErrChannel:
+		case msg := <-api.queues.email.ErrCh:
 			qmEmail, err := api.handleQueueError(msg, api.cfg, queue.EmailSendQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.email = qmEmail
-		case msg := <-api.queues.file.ErrChannel:
+		case msg := <-api.queues.file.ErrCh:
 			qmFile, err := api.handleQueueError(msg, api.cfg, queue.IpfsFileQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.file = qmFile
-		case msg := <-api.queues.ipns.ErrChannel:
+		case msg := <-api.queues.ipns.ErrCh:
 			qmIpns, err := api.handleQueueError(msg, api.cfg, queue.IpnsEntryQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.ipns = qmIpns
-		case msg := <-api.queues.key.ErrChannel:
+		case msg := <-api.queues.key.ErrCh:
 			qmKey, err := api.handleQueueError(msg, api.cfg, queue.IpfsKeyCreationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.key = qmKey
-		case msg := <-api.queues.payConfirm.ErrChannel:
+		case msg := <-api.queues.payConfirm.ErrCh:
 			qmPay, err := api.handleQueueError(msg, api.cfg, queue.PaymentConfirmationQueue, true)
 			if err != nil {
 				return server.Close()
 			}
 			api.queues.payConfirm = qmPay
-		case msg := <-api.queues.pin.ErrChannel:
+		case msg := <-api.queues.pin.ErrCh:
 			qmPin, err := api.handleQueueError(msg, api.cfg, queue.IpfsPinQueue, true)
 			if err != nil {
 				return server.Close()

--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -601,7 +601,7 @@ func TestAPI_Queue_Failures_Successful_Reinit(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	api.queues.cluster.ErrChannel <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
+	api.queues.cluster.ErrCh <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
 }
 
 func loadDatabase(cfg *config.TemporalConfig) (*gorm.DB, error) {

--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -136,10 +136,10 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
-								} else if err != nil && err.Error() == queue.ReconnectError {
+								} else if err != nil && err.Error() == queue.ErrReconnect {
 									continue
 								}
 								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -179,10 +179,10 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
-								} else if err != nil && err.Error() == queue.ReconnectError {
+								} else if err != nil && err.Error() == queue.ErrReconnect {
 									continue
 								}
 								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -222,10 +222,10 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
-								} else if err != nil && err.Error() == queue.ReconnectError {
+								} else if err != nil && err.Error() == queue.ErrReconnect {
 									continue
 								}
 								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -265,10 +265,10 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
-								} else if err != nil && err.Error() == queue.ReconnectError {
+								} else if err != nil && err.Error() == queue.ErrReconnect {
 									continue
 								}
 								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -308,10 +308,10 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
-								} else if err != nil && err.Error() == queue.ReconnectError {
+								} else if err != nil && err.Error() == queue.ErrReconnect {
 									continue
 								}
 								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -353,10 +353,10 @@ var commands = map[string]cmd.Cmd{
 							os.Exit(1)
 						}
 						waitGroup.Add(1)
-						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 							fmt.Println("failed to consume messages", err)
 							os.Exit(1)
-						} else if err != nil && err.Error() == queue.ReconnectError {
+						} else if err != nil && err.Error() == queue.ErrReconnect {
 							continue
 						}
 						// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
@@ -396,10 +396,10 @@ var commands = map[string]cmd.Cmd{
 							os.Exit(1)
 						}
 						waitGroup.Add(1)
-						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
 							fmt.Println("failed to consume messages", err)
 							os.Exit(1)
-						} else if err != nil && err.Error() == queue.ReconnectError {
+						} else if err != nil && err.Error() == queue.ErrReconnect {
 							continue
 						}
 						// this will only be true if we had a graceful exit to the queue process, aka CTRL+C

--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -136,7 +136,8 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+								err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+								if err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
 								} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -179,7 +180,8 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+								err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+								if err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
 								} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -222,7 +224,8 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+								err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+								if err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
 								} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -265,7 +268,8 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+								err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+								if err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
 								} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -308,7 +312,8 @@ var commands = map[string]cmd.Cmd{
 									os.Exit(1)
 								}
 								waitGroup.Add(1)
-								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+								err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+								if err != nil && err.Error() != queue.ErrReconnect {
 									fmt.Println("failed to consume messages", err)
 									os.Exit(1)
 								} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -353,7 +358,8 @@ var commands = map[string]cmd.Cmd{
 							os.Exit(1)
 						}
 						waitGroup.Add(1)
-						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+						err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+						if err != nil && err.Error() != queue.ErrReconnect {
 							fmt.Println("failed to consume messages", err)
 							os.Exit(1)
 						} else if err != nil && err.Error() == queue.ErrReconnect {
@@ -396,7 +402,8 @@ var commands = map[string]cmd.Cmd{
 							os.Exit(1)
 						}
 						waitGroup.Add(1)
-						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ErrReconnect {
+						err = qm.ConsumeMessages(ctx, waitGroup, db, &cfg)
+						if err != nil && err.Error() != queue.ErrReconnect {
 							fmt.Println("failed to consume messages", err)
 							os.Exit(1)
 						} else if err != nil && err.Error() == queue.ErrReconnect {

--- a/cmd/temporal/main.go
+++ b/cmd/temporal/main.go
@@ -121,23 +121,31 @@ var commands = map[string]cmd.Cmd{
 								fmt.Println("failed to start logger ", err)
 								os.Exit(1)
 							}
-							qm, err := queue.New(queue.IpnsEntryQueue, cfg.RabbitMQ.URL, false, logger)
-							if err != nil {
-								fmt.Println("failed to start queue", err)
-								os.Exit(1)
-							}
 							quitChannel := make(chan os.Signal)
 							signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 							waitGroup := &sync.WaitGroup{}
-							waitGroup.Add(1)
 							go func() {
 								fmt.Println(closeMessage)
 								<-quitChannel
 								cancel()
 							}()
-							if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-								fmt.Println("failed to consume messages", err)
-								os.Exit(1)
+							for {
+								qm, err := queue.New(queue.IpnsEntryQueue, cfg.RabbitMQ.URL, false, logger)
+								if err != nil {
+									fmt.Println("failed to start queue", err)
+									os.Exit(1)
+								}
+								waitGroup.Add(1)
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+									fmt.Println("failed to consume messages", err)
+									os.Exit(1)
+								} else if err != nil && err.Error() == queue.ReconnectError {
+									continue
+								}
+								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+								if err == nil {
+									break
+								}
 							}
 							waitGroup.Wait()
 						},
@@ -156,23 +164,31 @@ var commands = map[string]cmd.Cmd{
 								fmt.Println("failed to start logger ", err)
 								os.Exit(1)
 							}
-							qm, err := queue.New(queue.IpfsPinQueue, cfg.RabbitMQ.URL, false, logger)
-							if err != nil {
-								fmt.Println("failed to start queue", err)
-								os.Exit(1)
-							}
 							quitChannel := make(chan os.Signal)
 							signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 							waitGroup := &sync.WaitGroup{}
-							waitGroup.Add(1)
 							go func() {
 								fmt.Println(closeMessage)
 								<-quitChannel
 								cancel()
 							}()
-							if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-								fmt.Println("failed to consume messages", err)
-								os.Exit(1)
+							for {
+								qm, err := queue.New(queue.IpfsPinQueue, cfg.RabbitMQ.URL, false, logger)
+								if err != nil {
+									fmt.Println("failed to start queue", err)
+									os.Exit(1)
+								}
+								waitGroup.Add(1)
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+									fmt.Println("failed to consume messages", err)
+									os.Exit(1)
+								} else if err != nil && err.Error() == queue.ReconnectError {
+									continue
+								}
+								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+								if err == nil {
+									break
+								}
 							}
 							waitGroup.Wait()
 						},
@@ -191,23 +207,31 @@ var commands = map[string]cmd.Cmd{
 								fmt.Println("failed to start logger ", err)
 								os.Exit(1)
 							}
-							qm, err := queue.New(queue.IpfsFileQueue, cfg.RabbitMQ.URL, false, logger)
-							if err != nil {
-								fmt.Println("failed to start queue", err)
-								os.Exit(1)
-							}
 							quitChannel := make(chan os.Signal)
 							signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 							waitGroup := &sync.WaitGroup{}
-							waitGroup.Add(1)
 							go func() {
 								fmt.Println(closeMessage)
 								<-quitChannel
 								cancel()
 							}()
-							if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-								fmt.Println("failed to consume messages", err)
-								os.Exit(1)
+							for {
+								qm, err := queue.New(queue.IpfsFileQueue, cfg.RabbitMQ.URL, false, logger)
+								if err != nil {
+									fmt.Println("failed to start queue", err)
+									os.Exit(1)
+								}
+								waitGroup.Add(1)
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+									fmt.Println("failed to consume messages", err)
+									os.Exit(1)
+								} else if err != nil && err.Error() == queue.ReconnectError {
+									continue
+								}
+								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+								if err == nil {
+									break
+								}
 							}
 							waitGroup.Wait()
 						},
@@ -226,23 +250,31 @@ var commands = map[string]cmd.Cmd{
 								fmt.Println("failed to start logger ", err)
 								os.Exit(1)
 							}
-							qm, err := queue.New(queue.IpfsKeyCreationQueue, cfg.RabbitMQ.URL, false, logger)
-							if err != nil {
-								fmt.Println("failed to start queue", err)
-								os.Exit(1)
-							}
 							quitChannel := make(chan os.Signal)
 							signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 							waitGroup := &sync.WaitGroup{}
-							waitGroup.Add(1)
 							go func() {
 								fmt.Println(closeMessage)
 								<-quitChannel
 								cancel()
 							}()
-							if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-								fmt.Println("failed to consume messages", err)
-								os.Exit(1)
+							for {
+								qm, err := queue.New(queue.IpfsKeyCreationQueue, cfg.RabbitMQ.URL, false, logger)
+								if err != nil {
+									fmt.Println("failed to start queue", err)
+									os.Exit(1)
+								}
+								waitGroup.Add(1)
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+									fmt.Println("failed to consume messages", err)
+									os.Exit(1)
+								} else if err != nil && err.Error() == queue.ReconnectError {
+									continue
+								}
+								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+								if err == nil {
+									break
+								}
 							}
 							waitGroup.Wait()
 						},
@@ -261,23 +293,31 @@ var commands = map[string]cmd.Cmd{
 								fmt.Println("failed to start logger ", err)
 								os.Exit(1)
 							}
-							qm, err := queue.New(queue.IpfsClusterPinQueue, cfg.RabbitMQ.URL, false, logger)
-							if err != nil {
-								fmt.Println("failed to start queue", err)
-								os.Exit(1)
-							}
 							quitChannel := make(chan os.Signal)
 							signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 							waitGroup := &sync.WaitGroup{}
-							waitGroup.Add(1)
 							go func() {
 								fmt.Println(closeMessage)
 								<-quitChannel
 								cancel()
 							}()
-							if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-								fmt.Println("failed to consume messages", err)
-								os.Exit(1)
+							for {
+								qm, err := queue.New(queue.IpfsClusterPinQueue, cfg.RabbitMQ.URL, false, logger)
+								if err != nil {
+									fmt.Println("failed to start queue", err)
+									os.Exit(1)
+								}
+								waitGroup.Add(1)
+								if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+									fmt.Println("failed to consume messages", err)
+									os.Exit(1)
+								} else if err != nil && err.Error() == queue.ReconnectError {
+									continue
+								}
+								// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+								if err == nil {
+									break
+								}
 							}
 							waitGroup.Wait()
 						},
@@ -298,23 +338,31 @@ var commands = map[string]cmd.Cmd{
 						fmt.Println("failed to start logger ", err)
 						os.Exit(1)
 					}
-					qm, err := queue.New(queue.DatabaseFileAddQueue, cfg.RabbitMQ.URL, false, logger)
-					if err != nil {
-						fmt.Println("failed to start queue", err)
-						os.Exit(1)
-					}
 					quitChannel := make(chan os.Signal)
 					signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 					waitGroup := &sync.WaitGroup{}
-					waitGroup.Add(1)
 					go func() {
 						fmt.Println(closeMessage)
 						<-quitChannel
 						cancel()
 					}()
-					if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-						fmt.Println("failed to consume messages", err)
-						os.Exit(1)
+					for {
+						qm, err := queue.New(queue.DatabaseFileAddQueue, cfg.RabbitMQ.URL, false, logger)
+						if err != nil {
+							fmt.Println("failed to start queue", err)
+							os.Exit(1)
+						}
+						waitGroup.Add(1)
+						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+							fmt.Println("failed to consume messages", err)
+							os.Exit(1)
+						} else if err != nil && err.Error() == queue.ReconnectError {
+							continue
+						}
+						// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+						if err == nil {
+							break
+						}
 					}
 					waitGroup.Wait()
 				},
@@ -333,23 +381,31 @@ var commands = map[string]cmd.Cmd{
 						fmt.Println("failed to start logger ", err)
 						os.Exit(1)
 					}
-					qm, err := queue.New(queue.EmailSendQueue, cfg.RabbitMQ.URL, false, logger)
-					if err != nil {
-						fmt.Println("failed to start queue", err)
-						os.Exit(1)
-					}
 					quitChannel := make(chan os.Signal)
 					signal.Notify(quitChannel, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 					waitGroup := &sync.WaitGroup{}
-					waitGroup.Add(1)
 					go func() {
 						fmt.Println(closeMessage)
 						<-quitChannel
 						cancel()
 					}()
-					if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil {
-						fmt.Println("failed to consume messages", err)
-						os.Exit(1)
+					for {
+						qm, err := queue.New(queue.EmailSendQueue, cfg.RabbitMQ.URL, false, logger)
+						if err != nil {
+							fmt.Println("failed to start queue", err)
+							os.Exit(1)
+						}
+						waitGroup.Add(1)
+						if err := qm.ConsumeMessages(ctx, waitGroup, db, &cfg); err != nil && err.Error() != queue.ReconnectError {
+							fmt.Println("failed to consume messages", err)
+							os.Exit(1)
+						} else if err != nil && err.Error() == queue.ReconnectError {
+							continue
+						}
+						// this will only be true if we had a graceful exit to the queue process, aka CTRL+C
+						if err == nil {
+							break
+						}
 					}
 					waitGroup.Wait()
 				},

--- a/queue/database.go
+++ b/queue/database.go
@@ -26,7 +26,7 @@ func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGro
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/database.go
+++ b/queue/database.go
@@ -16,9 +16,9 @@ import (
 func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGroup, msgs <-chan amqp.Delivery) error {
 	uploadManager := models.NewUploadManager(qm.db)
 	userManager := models.NewUserManager(qm.db)
-	// register notify channel
-	ch := qm.RegisterConnectionClosure()
-	qm.l.Info("processing database file adds")
+	/*	// register notify channel
+		ch := qm.RegisterConnectionClosure()
+	*/qm.l.Info("processing database file adds")
 	for {
 		select {
 		case d := <-msgs:
@@ -28,7 +28,7 @@ func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGro
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/database.go
+++ b/queue/database.go
@@ -32,7 +32,7 @@ func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGro
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }

--- a/queue/database.go
+++ b/queue/database.go
@@ -16,9 +16,7 @@ import (
 func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGroup, msgs <-chan amqp.Delivery) error {
 	uploadManager := models.NewUploadManager(qm.db)
 	userManager := models.NewUserManager(qm.db)
-	/*	// register notify channel
-		ch := qm.RegisterConnectionClosure()
-	*/qm.l.Info("processing database file adds")
+	qm.l.Info("processing database file adds")
 	for {
 		select {
 		case d := <-msgs:

--- a/queue/database.go
+++ b/queue/database.go
@@ -26,7 +26,7 @@ func (qm *Manager) ProcessDatabaseFileAdds(ctx context.Context, wg *sync.WaitGro
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/exchanges.go
+++ b/queue/exchanges.go
@@ -40,8 +40,8 @@ func (qm *Manager) declareIPFSKeyExchange() error {
 }
 
 // SetupExchange is used to setup our various exchanges
-func (qm *Manager) setupExchange(queueName string) error {
-	switch queueName {
+func (qm *Manager) setupExchange(queueType Queue) error {
+	switch queueType {
 	case IpfsPinQueue:
 		qm.ExchangeName = PinExchange
 		return qm.declareIPFSPinExchange()

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -47,7 +47,7 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }
@@ -83,7 +83,7 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }
@@ -125,7 +125,7 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -41,7 +41,7 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -77,7 +77,7 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -119,7 +119,7 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -31,7 +31,6 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 		return err
 	}
 	userManager := models.NewUserManager(qm.db)
-	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs key creation requests")
 	for {
 		select {
@@ -42,7 +41,7 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -68,7 +67,6 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 		qm.l.Errorw("failed to intialize cluster pin queue connection", "error", err.Error())
 		return err
 	}
-	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs pins")
 	for {
 		select {
@@ -79,7 +77,7 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -111,7 +109,6 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 	ue := models.NewEncryptedUploadManager(qm.db)
 	userManager := models.NewUserManager(qm.db)
 	networkManager := models.NewHostedIPFSNetworkManager(qm.db)
-	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs files")
 	for {
 		select {
@@ -122,7 +119,7 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -31,6 +31,7 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 		return err
 	}
 	userManager := models.NewUserManager(qm.db)
+	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs key creation requests")
 	for {
 		select {
@@ -41,6 +42,13 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
+		case msg := <-ch:
+			qm.Close()
+			wg.Done()
+			qm.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"error", msg.Error())
+			return errors.New(ReconnectError)
 		}
 	}
 }
@@ -60,6 +68,7 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 		qm.l.Errorw("failed to intialize cluster pin queue connection", "error", err.Error())
 		return err
 	}
+	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs pins")
 	for {
 		select {
@@ -70,6 +79,13 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 			qm.Close()
 			wg.Done()
 			return nil
+		case msg := <-ch:
+			qm.Close()
+			wg.Done()
+			qm.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"error", msg.Error())
+			return errors.New(ReconnectError)
 		}
 	}
 }
@@ -95,6 +111,7 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 	ue := models.NewEncryptedUploadManager(qm.db)
 	userManager := models.NewUserManager(qm.db)
 	networkManager := models.NewHostedIPFSNetworkManager(qm.db)
+	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs files")
 	for {
 		select {
@@ -105,6 +122,13 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 			qm.Close()
 			wg.Done()
 			return nil
+		case msg := <-ch:
+			qm.Close()
+			wg.Done()
+			qm.l.Errorw(
+				"a protocol connection error stopping rabbitmq was received",
+				"error", msg.Error())
+			return errors.New(ReconnectError)
 		}
 	}
 }

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -41,7 +41,7 @@ func (qm *Manager) ProcessIPFSKeyCreation(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -77,7 +77,7 @@ func (qm *Manager) ProccessIPFSPins(ctx context.Context, wg *sync.WaitGroup, msg
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(
@@ -119,7 +119,7 @@ func (qm *Manager) ProccessIPFSFiles(ctx context.Context, wg *sync.WaitGroup, ms
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs_cluster.go
+++ b/queue/ipfs_cluster.go
@@ -29,7 +29,7 @@ func (qm *Manager) ProcessIPFSClusterPins(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs_cluster.go
+++ b/queue/ipfs_cluster.go
@@ -19,7 +19,6 @@ func (qm *Manager) ProcessIPFSClusterPins(ctx context.Context, wg *sync.WaitGrou
 		return err
 	}
 	uploadManager := models.NewUploadManager(qm.db)
-	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipfs cluster pin requests")
 	for {
 		select {
@@ -30,7 +29,7 @@ func (qm *Manager) ProcessIPFSClusterPins(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs_cluster.go
+++ b/queue/ipfs_cluster.go
@@ -29,7 +29,7 @@ func (qm *Manager) ProcessIPFSClusterPins(ctx context.Context, wg *sync.WaitGrou
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipfs_cluster.go
+++ b/queue/ipfs_cluster.go
@@ -35,7 +35,7 @@ func (qm *Manager) ProcessIPFSClusterPins(ctx context.Context, wg *sync.WaitGrou
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }

--- a/queue/ipns.go
+++ b/queue/ipns.go
@@ -59,7 +59,7 @@ func (qm *Manager) ProcessIPNSEntryCreationRequests(ctx context.Context, wg *syn
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }

--- a/queue/ipns.go
+++ b/queue/ipns.go
@@ -53,7 +53,7 @@ func (qm *Manager) ProcessIPNSEntryCreationRequests(ctx context.Context, wg *syn
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipns.go
+++ b/queue/ipns.go
@@ -53,7 +53,7 @@ func (qm *Manager) ProcessIPNSEntryCreationRequests(ctx context.Context, wg *syn
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/ipns.go
+++ b/queue/ipns.go
@@ -43,7 +43,6 @@ func (qm *Manager) ProcessIPNSEntryCreationRequests(ctx context.Context, wg *syn
 		return err
 	}
 	ipnsManager := models.NewIPNSManager(qm.db)
-	ch := qm.RegisterConnectionClosure()
 	qm.l.Info("processing ipns entry creation requests")
 	for {
 		select {
@@ -54,7 +53,7 @@ func (qm *Manager) ProcessIPNSEntryCreationRequests(ctx context.Context, wg *syn
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -18,7 +18,6 @@ func (qm *Manager) ProcessMailSends(ctx context.Context, wg *sync.WaitGroup, db 
 		return err
 	}
 	qm.l.Info("processing email send requests")
-	ch := qm.RegisterConnectionClosure()
 	for {
 		select {
 		case d := <-msgs:
@@ -28,7 +27,7 @@ func (qm *Manager) ProcessMailSends(ctx context.Context, wg *sync.WaitGroup, db 
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-ch:
+		case msg := <-qm.errChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -27,7 +27,7 @@ func (qm *Manager) ProcessMailSends(ctx context.Context, wg *sync.WaitGroup, db 
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.ErrChannel:
+		case msg := <-qm.ErrCh:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -27,7 +27,7 @@ func (qm *Manager) ProcessMailSends(ctx context.Context, wg *sync.WaitGroup, db 
 			qm.Close()
 			wg.Done()
 			return nil
-		case msg := <-qm.errChannel:
+		case msg := <-qm.ErrChannel:
 			qm.Close()
 			wg.Done()
 			qm.l.Errorw(

--- a/queue/mail.go
+++ b/queue/mail.go
@@ -33,7 +33,7 @@ func (qm *Manager) ProcessMailSends(ctx context.Context, wg *sync.WaitGroup, db 
 			qm.l.Errorw(
 				"a protocol connection error stopping rabbitmq was received",
 				"error", msg.Error())
-			return errors.New(ReconnectError)
+			return errors.New(ErrReconnect)
 		}
 	}
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -210,7 +210,7 @@ func (qm *Manager) PublishMessage(body interface{}) error {
 // RegisterConnectionClosure is used to register a channel which we may receive
 // connection level errors. This covers all channel, and connection errors.
 func (qm *Manager) RegisterConnectionClosure() {
-	qm.errChannel = qm.connection.NotifyClose(make(chan *amqp.Error))
+	qm.ErrChannel = qm.connection.NotifyClose(make(chan *amqp.Error))
 }
 
 // Close is used to close our queue resources

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -206,6 +206,12 @@ func (qm *Manager) PublishMessage(body interface{}) error {
 	return nil
 }
 
+// RegisterConnectionClosure is used to register a channel which we may receive
+// connection level errors. This covers all channel, and connection errors.
+func (qm *Manager) RegisterConnectionClosure(ch chan *amqp.Error) chan *amqp.Error {
+	return qm.connection.NotifyClose(ch)
+}
+
 // Close is used to close our queue resources
 func (qm *Manager) Close() error {
 	// closing the connection also closes the channel

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -208,8 +208,8 @@ func (qm *Manager) PublishMessage(body interface{}) error {
 
 // RegisterConnectionClosure is used to register a channel which we may receive
 // connection level errors. This covers all channel, and connection errors.
-func (qm *Manager) RegisterConnectionClosure(ch chan *amqp.Error) chan *amqp.Error {
-	return qm.connection.NotifyClose(ch)
+func (qm *Manager) RegisterConnectionClosure() chan *amqp.Error {
+	return qm.connection.NotifyClose(make(chan *amqp.Error))
 }
 
 // Close is used to close our queue resources

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -209,7 +209,7 @@ func (qm *Manager) PublishMessage(body interface{}) error {
 // RegisterConnectionClosure is used to register a channel which we may receive
 // connection level errors. This covers all channel, and connection errors.
 func (qm *Manager) RegisterConnectionClosure() {
-	qm.ErrChannel = qm.connection.NotifyClose(make(chan *amqp.Error))
+	qm.ErrCh = qm.connection.NotifyClose(make(chan *amqp.Error))
 }
 
 // Close is used to close our queue resources

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -14,7 +14,7 @@ import (
 )
 
 // New is used to instantiate a new connection to rabbitmq as a publisher or consumer
-func New(queue, url string, publish bool, logger *zap.SugaredLogger) (*Manager, error) {
+func New(queue Queue, url string, publish bool, logger *zap.SugaredLogger) (*Manager, error) {
 	conn, err := setupConnection(url)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func New(queue, url string, publish bool, logger *zap.SugaredLogger) (*Manager, 
 		queueType = "consumer"
 	}
 	// create base queue manager
-	qm := Manager{connection: conn, QueueName: queue, l: logger.Named(queue + "." + queueType)}
+	qm := Manager{connection: conn, QueueName: queue, l: logger.Named(queue.String() + "." + queueType)}
 	// open a channel
 	if err := qm.openChannel(); err != nil {
 		return nil, err
@@ -35,7 +35,6 @@ func New(queue, url string, publish bool, logger *zap.SugaredLogger) (*Manager, 
 	// if we aren't publishing, and are consuming
 	// setup a queue to receive messages on
 	if !publish {
-		qm.Service = queue
 		if err = qm.declareQueue(); err != nil {
 			return nil, err
 		}
@@ -76,12 +75,12 @@ func (qm *Manager) declareQueue() error {
 	// we declare the queue as durable so that even if rabbitmq server stops
 	// our messages won't be lost
 	q, err := qm.channel.QueueDeclare(
-		qm.QueueName, // name
-		true,         // durable
-		false,        // delete when unused
-		false,        // exclusive
-		false,        // no-wait
-		nil,          // arguments
+		qm.QueueName.String(), // name
+		true,                  // durable
+		false,                 // delete when unused
+		false,                 // exclusive
+		false,                 // no-wait
+		nil,                   // arguments
 	)
 	if err != nil {
 		return err
@@ -108,11 +107,11 @@ func (qm *Manager) ConsumeMessages(ctx context.Context, wg *sync.WaitGroup, db *
 	switch qm.ExchangeName {
 	case PinExchange, IpfsKeyExchange:
 		if err := qm.channel.QueueBind(
-			qm.QueueName,    // name of the queue
-			"",              // routing key
-			qm.ExchangeName, // exchange
-			false,           // noWait
-			nil,             // arguments
+			qm.QueueName.String(), // name of the queue
+			"",                    // routing key
+			qm.ExchangeName,       // exchange
+			false,                 // noWait
+			nil,                   // arguments
 		); err != nil {
 			return err
 		}
@@ -123,20 +122,20 @@ func (qm *Manager) ConsumeMessages(ctx context.Context, wg *sync.WaitGroup, db *
 	// we do not auto-ack, as if a consumer dies we don't want the message to be lost
 	// not specifying the consumer name uses an automatically generated id
 	msgs, err := qm.channel.Consume(
-		qm.QueueName, // queue
-		"",           // consumer
-		false,        // auto-ack
-		false,        // exclusive
-		false,        // no-local
-		false,        // no-wait
-		nil,          // args
+		qm.QueueName.String(), // queue
+		"",                    // consumer
+		false,                 // auto-ack
+		false,                 // exclusive
+		false,                 // no-local
+		false,                 // no-wait
+		nil,                   // args
 	)
 	if err != nil {
 		return err
 	}
 
 	// check the queue name
-	switch qm.Service {
+	switch qm.QueueName {
 	// only parse database file requests
 	case DatabaseFileAddQueue:
 		return qm.ProcessDatabaseFileAdds(ctx, wg, msgs)
@@ -192,10 +191,10 @@ func (qm *Manager) PublishMessage(body interface{}) error {
 		return err
 	}
 	if err = qm.channel.Publish(
-		"",           // exchange - this is left empty, and becomes the default exchange
-		qm.QueueName, // routing key
-		false,        // mandatory
-		false,        // immediate
+		"",                    // exchange - this is left empty, and becomes the default exchange
+		qm.QueueName.String(), // routing key
+		false,                 // mandatory
+		false,                 // immediate
 		amqp.Publishing{
 			DeliveryMode: amqp.Persistent, // messages will persist through crashes, etc..
 			ContentType:  "text/plain",

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -208,7 +208,7 @@ func TestQueue_ConnectionClosure(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
-				if err := qmPublisher.ConsumeMessages(context.Background(), wg, db, cfg); err != nil && err.Error() != ReconnectError {
+				if err := qmPublisher.ConsumeMessages(context.Background(), wg, db, cfg); err != nil && err.Error() != ErrReconnect {
 					t.Fatal(err)
 				}
 			}()

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -109,9 +109,9 @@ func TestRegisterChannelClosure(t *testing.T) {
 	// declare the channel to receive messages on
 	qmPublisher.RegisterConnectionClosure()
 	go func() {
-		qmPublisher.ErrChannel <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
+		qmPublisher.ErrCh <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
 	}()
-	msg := <-qmPublisher.ErrChannel
+	msg := <-qmPublisher.ErrCh
 	if msg.Code != 400 {
 		t.Fatal("bad code received")
 	}
@@ -213,7 +213,7 @@ func TestQueue_ConnectionClosure(t *testing.T) {
 				}
 			}()
 			go func() {
-				qmPublisher.ErrChannel <- &amqp.Error{Code: 400, Reason: "error", Server: true, Recover: false}
+				qmPublisher.ErrCh <- &amqp.Error{Code: 400, Reason: "error", Server: true, Recover: false}
 			}()
 			wg.Wait()
 		})

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -106,14 +107,14 @@ func TestRegisterChannelClosure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		if err := qmPublisher.Close(); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	/*	defer func() {
+			if err := qmPublisher.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	*/
 	// declare the channel to receive messages on
-	ch := make(chan *amqp.Error)
-	ch = qmPublisher.RegisterConnectionClosure(ch)
+	ch := qmPublisher.RegisterConnectionClosure()
 	go func() {
 		ch <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
 	}()
@@ -130,6 +131,11 @@ func TestRegisterChannelClosure(t *testing.T) {
 	if msg.Recover {
 		t.Fatal("bad recover")
 	}
+	if err := qmPublisher.Close(); err != nil {
+		t.Fatal(err)
+	}
+	msg = <-ch
+	fmt.Printf("%+v\n", msg)
 }
 
 func TestQueue_RefundCredits(t *testing.T) {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -109,9 +109,9 @@ func TestRegisterChannelClosure(t *testing.T) {
 	// declare the channel to receive messages on
 	qmPublisher.RegisterConnectionClosure()
 	go func() {
-		qmPublisher.errChannel <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
+		qmPublisher.ErrChannel <- &amqp.Error{Code: 400, Reason: "test", Server: true, Recover: false}
 	}()
-	msg := <-qmPublisher.errChannel
+	msg := <-qmPublisher.ErrChannel
 	if msg.Code != 400 {
 		t.Fatal("bad code received")
 	}
@@ -213,7 +213,7 @@ func TestQueue_ConnectionClosure(t *testing.T) {
 				}
 			}()
 			go func() {
-				qmPublisher.errChannel <- &amqp.Error{Code: 400, Reason: "error", Server: true, Recover: false}
+				qmPublisher.ErrChannel <- &amqp.Error{Code: 400, Reason: "error", Server: true, Recover: false}
 			}()
 			wg.Wait()
 		})

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -27,7 +27,7 @@ const (
 
 func TestQueue_Publish(t *testing.T) {
 	type args struct {
-		queueName string
+		queueName Queue
 		publish   bool
 	}
 	tests := []struct {
@@ -185,19 +185,19 @@ func TestQueue_ConnectionClosure(t *testing.T) {
 		t.Fatal(err)
 	}
 	type args struct {
-		queueName string
+		queueName Queue
 	}
 	tests := []struct {
 		name string
 		args args
 	}{
-		{DatabaseFileAddQueue, args{DatabaseFileAddQueue}},
-		{IpfsFileQueue, args{IpfsFileQueue}},
-		{IpfsClusterPinQueue, args{IpfsClusterPinQueue}},
-		{EmailSendQueue, args{EmailSendQueue}},
-		{IpnsEntryQueue, args{IpnsEntryQueue}},
-		{IpfsPinQueue, args{IpfsPinQueue}},
-		{IpfsKeyCreationQueue, args{IpfsKeyCreationQueue}},
+		{DatabaseFileAddQueue.String(), args{DatabaseFileAddQueue}},
+		{IpfsFileQueue.String(), args{IpfsFileQueue}},
+		{IpfsClusterPinQueue.String(), args{IpfsClusterPinQueue}},
+		{EmailSendQueue.String(), args{EmailSendQueue}},
+		{IpnsEntryQueue.String(), args{IpnsEntryQueue}},
+		{IpfsPinQueue.String(), args{IpfsPinQueue}},
+		{IpfsKeyCreationQueue.String(), args{IpfsKeyCreationQueue}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/queue/types.go
+++ b/queue/types.go
@@ -10,28 +10,35 @@ import (
 	"github.com/streadway/amqp"
 )
 
-// Various variables used by our queue package
+// Various variables and types used by our queue package
+
+// Queue is a typed string used to declare the various queue names
+type Queue string
+
+func (qt Queue) String() string {
+	return string(qt)
+}
 
 var (
 	nilTime time.Time
 	// DatabaseFileAddQueue is a queue used for simple file adds
-	DatabaseFileAddQueue = "dfa-queue"
+	DatabaseFileAddQueue Queue = "dfa-queue"
 	// IpfsPinQueue is a queue used for ipfs pins
-	IpfsPinQueue = "ipfs-pin-queue"
+	IpfsPinQueue Queue = "ipfs-pin-queue"
 	// IpfsFileQueue is a queue used for advanced file adds
-	IpfsFileQueue = "ipfs-file-queue"
+	IpfsFileQueue Queue = "ipfs-file-queue"
 	// IpfsClusterPinQueue is a queue used for ipfs cluster pins
-	IpfsClusterPinQueue = "ipfs-cluster-add-queue"
+	IpfsClusterPinQueue Queue = "ipfs-cluster-add-queue"
 	// EmailSendQueue is a queue used to handle sending email messages
-	EmailSendQueue = "email-send-queue"
+	EmailSendQueue Queue = "email-send-queue"
 	// IpnsEntryQueue is a queue used to handle ipns entry creation
-	IpnsEntryQueue = "ipns-entry-queue"
+	IpnsEntryQueue Queue = "ipns-entry-queue"
 	// IpfsKeyCreationQueue is a queue used to handle ipfs key creation
-	IpfsKeyCreationQueue = "ipfs-key-creation-queue"
+	IpfsKeyCreationQueue Queue = "ipfs-key-creation-queue"
 	// PaymentConfirmationQueue is a queue used to handle payment confirmations
-	PaymentConfirmationQueue = "payment-confirmation-queue"
+	PaymentConfirmationQueue Queue = "payment-confirmation-queue"
 	// DashPaymentConfirmationQueue is a queue used to handle confirming dash payments
-	DashPaymentConfirmationQueue = "dash-payment-confirmation-queue"
+	DashPaymentConfirmationQueue Queue = "dash-payment-confirmation-queue"
 	// AdminEmail is the email used to notify RTrade about any critical errors
 	AdminEmail = "temporal.reports@rtradetechnologies.com"
 	// IpfsPinFailedContent is a to-be formatted message sent on IPFS pin failures
@@ -68,8 +75,7 @@ type Manager struct {
 	db           *gorm.DB
 	cfg          *config.TemporalConfig
 	ErrChannel   chan *amqp.Error
-	QueueName    string
-	Service      string
+	QueueName    Queue
 	ExchangeName string
 }
 

--- a/queue/types.go
+++ b/queue/types.go
@@ -74,7 +74,7 @@ type Manager struct {
 	l            *zap.SugaredLogger
 	db           *gorm.DB
 	cfg          *config.TemporalConfig
-	ErrChannel   chan *amqp.Error
+	ErrCh   chan *amqp.Error
 	QueueName    Queue
 	ExchangeName string
 }

--- a/queue/types.go
+++ b/queue/types.go
@@ -74,7 +74,7 @@ type Manager struct {
 	l            *zap.SugaredLogger
 	db           *gorm.DB
 	cfg          *config.TemporalConfig
-	ErrCh   chan *amqp.Error
+	ErrCh        chan *amqp.Error
 	QueueName    Queue
 	ExchangeName string
 }

--- a/queue/types.go
+++ b/queue/types.go
@@ -67,6 +67,7 @@ type Manager struct {
 	l            *zap.SugaredLogger
 	db           *gorm.DB
 	cfg          *config.TemporalConfig
+	errChannel   chan *amqp.Error
 	QueueName    string
 	Service      string
 	ExchangeName string

--- a/queue/types.go
+++ b/queue/types.go
@@ -67,7 +67,7 @@ type Manager struct {
 	l            *zap.SugaredLogger
 	db           *gorm.DB
 	cfg          *config.TemporalConfig
-	errChannel   chan *amqp.Error
+	ErrChannel   chan *amqp.Error
 	QueueName    string
 	Service      string
 	ExchangeName string

--- a/queue/types.go
+++ b/queue/types.go
@@ -61,7 +61,7 @@ var (
 	PaymentConfirmationFailedSubject = "Payment Confirmation Failed"
 	// PaymentConfirmationFailedContent is a content used when a payment confirmation failure occurs
 	PaymentConfirmationFailedContent = "Payment failed for content hash %s with error %s"
-	// ReconnectError is an error emitted when a protocol connection error occurs
+	// ErrReconnect is an error emitted when a protocol connection error occurs
 	// It is used to signal reconnect of queue consumers and publishers
 	ErrReconnect = "protocol connection error, reconnect"
 )

--- a/queue/types.go
+++ b/queue/types.go
@@ -54,6 +54,9 @@ var (
 	PaymentConfirmationFailedSubject = "Payment Confirmation Failed"
 	// PaymentConfirmationFailedContent is a content used when a payment confirmation failure occurs
 	PaymentConfirmationFailedContent = "Payment failed for content hash %s with error %s"
+	// ReconnectError is an error emitted when a protocol connection error occurs
+	// It is used to signal reconnect of queue consumers and publishers
+	ReconnectError = "protocol connection error, reconnect"
 )
 
 // Manager is a helper struct to interact with rabbitmq


### PR DESCRIPTION
## :construction_worker: Purpose
Occassionally due to connection errors the RabbitMQ consumers and publishers will die, and need to be reconnected. This PR ensures that if the consumers die due to connection errors, they will be recreated.

Allow queue re-building within the API should it also receive connection errors. The one condition with this is that if the re-establish fails, the API process closes. This is the only way I can think of allowing our load-balancer to redirect requests to an API that's not having any issues. From what I can tell, this issue is unlikely to effect both our API instances at once, although that could always happen in which case we should have a service like `monit` on our servers that restarts downed services

## :rocket: Changes
Add function to `Queue::Manager` that creates a channel to receive protocol connection errors on.
In this error is triggered, recreate queue consumers

## :warning: Breaking Changes
None

