### PR TITLE
RTNS PubSub

### DIFF
--- a/rtns/host.go
+++ b/rtns/host.go
@@ -55,6 +55,10 @@ func NewPublisher(pk ci.PrivKey, permanent bool, swarmAddrs ...string) (*Publish
 		Online:    true,
 		Permanent: permanent,
 		Repo:      &repoMock,
+		// this is used to enable ipns pubsub
+		ExtraOpts: map[string]bool{
+			"ipnsps": true,
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## :construction_worker: Purpose
IPFS allows for faster publish/discovery of IPNS records utilizing pubsub, this enables it.


## :rocket: Changes
When initializing the `rtns` node, add extra opts to enable IPNS pubsub


## :warning: Breaking Changes
None

