### PR TITLE
Key Exchange Fix: TEM-223

### DIFF
--- a/CHANGELOG-V2.md
+++ b/CHANGELOG-V2.md
@@ -3,6 +3,10 @@
 This document tracks changes to Temporal and its related projects for all `v2.x.x`
 releases. See our [versioning policy](/VERSIONING.md) for more details.
 
+## v2.0.2
+
+* queue: fix key creation queue not having all consumers process the same message ([#303](https://github.com/RTradeLtd/Temporal/pull/303))
+
 ## v2.0.1
 
 * docs: update README for V2-specific things ([#301](https://github.com/RTradeLtd/Temporal/pull/301))

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -2,6 +2,8 @@ package queue
 
 import (
 	"context"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +23,42 @@ const (
 	testLogFilePath   = "../testenv/"
 	testCfgPath       = "../testenv/config.json"
 )
+
+func TestParseQueueName(t *testing.T) {
+	qm := Manager{}
+	if err := qm.parseQueueName(IpfsKeyCreationQueue); err != nil {
+		t.Fatal(err)
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok := strings.Contains(qm.QueueName.String(), host); !ok {
+		t.Fatal("failed to properly parse queue name")
+	}
+}
+
+func TestParseQueueFull(t *testing.T) {
+	cfg, err := config.LoadConfig(testCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loggerConsumer, err := log.NewLogger("", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qmConsumer, err := New(IpfsKeyCreationQueue, testRabbitAddress, false, cfg, loggerConsumer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok := strings.Contains(qmConsumer.QueueName.String(), host); !ok {
+		t.Fatal("failed to properly parse queue name")
+	}
+}
 
 func TestQueue_Publish(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## :construction_worker: Purpose
Key creation messages are supposed to be sent to all active consumers, instead they were only being sent to one.


## :rocket: Changes
The problem was that all key consumers were registering under the same queue, which with the fanout exchange effectively because round-robin distribution, as there is a single queue being registered under exchange. The fix was to generate a some-what unique queue name, and bind that to the exchange.  This then allow the fanout exchange to route to all the queues attached to the exchange.


## :warning: Breaking Changes
None

