### PR TITLE
api/v2: re-order private network database update

### DIFF
--- a/CHANGELOG-V2.md
+++ b/CHANGELOG-V2.md
@@ -3,6 +3,10 @@
 This document tracks changes to Temporal and its related projects for all `v2.x.x`
 releases. See our [versioning policy](/VERSIONING.md) for more details.
 
+## v2.0.3
+
+* api/v2: fix private network creation ([#304](https://github.com/RTradeLtd/Temporal/pull/304))
+
 ## v2.0.2
 
 * queue: fix key creation queue not having all consumers process the same message ([#303](https://github.com/RTradeLtd/Temporal/pull/303))


### PR DESCRIPTION
## :construction_worker: Purpose
Private network creation was broken, due to Nexus expecting the network details to be in the database.


## :rocket: Changes
Create network entry in database, then trigger network creation on Nexus


## :warning: Breaking Changes
None

