### PR TITLE
api/v2: fix cant upload bug

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -33,6 +33,7 @@ const (
 	testSwarmKey       = "7fcb5a1b19bdda69da7307162e3becd2d6bd485d5aad778470b305f3f306cf79"
 	testBootstrapPeer1 = "/ip4/172.218.49.115/tcp/5002/ipfs/Qmf964tiE9JaxqntDsSBGasD4aaofPQtfYZyMSJJkRrVTQ"
 	testBootstrapPeer2 = "/ip4/192.168.1.249/tcp/4001/ipfs/QmXuGVPzEz2Ji7g54AYyqoobRJNHqtnrfaEceAes2bTKMh"
+	testPIN            = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
 )
 
 var (

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -160,7 +160,7 @@ func (api *API) pinIPNSHash(c *gin.Context) {
 	// upload content matching this hash before, and we don't want to charge them
 	// so we should gracefully abort further processing
 	if err == nil || upload != nil {
-		Respond(c, http.StatusOK, gin.H{"response": alreadyUploadedMessage})
+		Respond(c, http.StatusBadRequest, gin.H{"response": alreadyUploadedMessage})
 		return
 	}
 	// get size of object

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -176,14 +176,7 @@ func (api *API) addFile(c *gin.Context) {
 	api.l.Debug("user", username, "file_size_in_gb", fileSizeInGB)
 	// validate if they can upload an object of this size
 	if err := api.usage.CanUpload(username, fileSizeInGB); err != nil {
-		usages, err := api.usage.FindByUserName(username)
-		if err != nil {
-			api.LogError(c, err, eh.CantUploadError)(http.StatusBadRequest)
-			return
-		}
-		api.LogError(c, err,
-			api.formatUploadErrorMessage(fileHandler.Filename, usages.CurrentDataUsedBytes, usages.MonthlyDataLimitBytes),
-		)
+		api.LogError(c, err, eh.CantUploadError)(http.StatusBadRequest)
 		return
 	}
 	// calculate code of upload

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -53,9 +53,9 @@ func (api *API) pinHashLocally(c *gin.Context) {
 	upload, err := api.upm.FindUploadByHashAndUserAndNetwork(username, hash, "public")
 	// by this conditional if statement passing, it means the user has
 	// upload content matching this hash before, and we don't want to charge them
-	// so we should gracefully abort further processing
+	// so we should abort further processing
 	if err == nil || upload != nil {
-		Respond(c, http.StatusOK, gin.H{"response": alreadyUploadedMessage})
+		Respond(c, http.StatusBadRequest, gin.H{"response": alreadyUploadedMessage})
 		return
 	}
 	// get object size
@@ -168,7 +168,7 @@ func (api *API) addFile(c *gin.Context) {
 	// upload content matching this hash before, and we don't want to charge them
 	// so we should gracefully abort further processing
 	if err == nil || upload != nil {
-		Respond(c, http.StatusOK, gin.H{"response": alreadyUploadedMessage})
+		Respond(c, http.StatusBadRequest, gin.H{"response": alreadyUploadedMessage})
 		return
 	}
 	// format size of file into gigabytes

--- a/api/v2/routes_rtfs_test.go
+++ b/api/v2/routes_rtfs_test.go
@@ -125,7 +125,7 @@ func Test_API_Routes_IPFS_Public(t *testing.T) {
 	urlValues = url.Values{}
 	urlValues.Add("hold_time", "5")
 	if err := sendRequest(
-		api, "POST", "/v2/ipfs/public/pin/"+hash, 200, nil, urlValues, &apiResp,
+		api, "POST", "/v2/ipfs/public/pin/"+testPIN, 200, nil, urlValues, &apiResp,
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## :construction_worker: Purpose
Fix internal server error when failing due to account limitation, respond with proper status code on already upload


## :rocket: Changes
* When uploading a file through `API::AddFile`, if you were at your account limit for storage space, panic would occur, instead of reporting the expected error message
* When uploading or pinning, if the hash is already detected responded with `http.StatusBadRequest` instead of `http.StatusOK`

## :warning: Breaking Changes
None

