### PR TITLE
Allow CORS Configuration Via Config File

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,12 +34,12 @@
   version = "v2.0.1"
 
 [[projects]]
-  branch = "api/cors"
-  digest = "1:e8e74e2a66d69ca9afc4a74038a42d69be546d588154c3177b260550b8edcc31"
+  digest = "1:9cbed820d2a459786e47ab2a67b3e3b04c58b006597fdf80d58ef4cfb9e81e7c"
   name = "github.com/RTradeLtd/config"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c3f48ca1b48fb2f4702f470407b0c385c3c94058"
+  revision = "b0ee70d215bfa47c475262b6c7d01760a0b70233"
+  version = "v2.0.4"
 
 [[projects]]
   digest = "1:8859d83d94d112382fbdd97fc04c2ce196ea044f271ffe8e170826b25131a4f0"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,12 +34,12 @@
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:26bd7fc13dbe68c8f3cb985d6a365d990fef7a2bfefc6cc4aa631bc51b1fedab"
+  branch = "api/cors"
+  digest = "1:e8e74e2a66d69ca9afc4a74038a42d69be546d588154c3177b260550b8edcc31"
   name = "github.com/RTradeLtd/config"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4140b3d6ec5751c110f0660a52b1b3209b95ddd6"
-  version = "v2.0.3"
+  revision = "c3f48ca1b48fb2f4702f470407b0c385c3c94058"
 
 [[projects]]
   digest = "1:8859d83d94d112382fbdd97fc04c2ce196ea044f271ffe8e170826b25131a4f0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@ ignored = ["github.com/karalabe/hid", "github.com/satori/go.uuid", "github.com/i
 
 [[override]]
   name = "github.com/RTradeLtd/config"
-  version = "~v2.0.0"
+  branch = "api/cors"
 
 [[override]]
   name = "github.com/RTradeLtd/kaas"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@ ignored = ["github.com/karalabe/hid", "github.com/satori/go.uuid", "github.com/i
 
 [[override]]
   name = "github.com/RTradeLtd/config"
-  branch = "api/cors"
+  version = "~v2.0.0"
 
 [[override]]
   name = "github.com/RTradeLtd/kaas"

--- a/api/middleware/cors.go
+++ b/api/middleware/cors.go
@@ -6,11 +6,13 @@ import (
 )
 
 var (
-	allowedOrigins = []string{"https://temporal.cloud"}
+	// DefaultAllowedOrigins are the default allowed origins for the api, allowing for access
+	// via both of our internet uplinks when using the web interface.
+	DefaultAllowedOrigins = []string{"https://temporal.cloud", "https://backup.temporal.cloud"}
 )
 
 // CORSMiddleware is used to load our CORS handling logic
-func CORSMiddleware(devMode bool) gin.HandlerFunc {
+func CORSMiddleware(devMode bool, allowedOrigins []string) gin.HandlerFunc {
 	corsConfig := cors.DefaultConfig()
 	if devMode {
 		corsConfig.AllowAllOrigins = true

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -76,23 +76,11 @@ func TestJwtMiddleware(t *testing.T) {
 }
 
 func TestCORSMiddleware(t *testing.T) {
-	if len(allowedOrigins) == 0 {
-		t.Fatal("bad allowed origins configuration")
-	}
-	var validOrigins bool
-	for _, v := range allowedOrigins {
-		if v == "https://temporal.cloud" {
-			validOrigins = true
-		}
-	}
-	if !validOrigins {
-		t.Fatal("no valid origins configured")
-	}
-	cors := CORSMiddleware(true)
+	cors := CORSMiddleware(true, DefaultAllowedOrigins)
 	if reflect.TypeOf(cors).String() != "gin.HandlerFunc" {
 		t.Fatal("failed to reflect correct middleware type")
 	}
-	cors = CORSMiddleware(false)
+	cors = CORSMiddleware(false, DefaultAllowedOrigins)
 	if reflect.TypeOf(cors).String() != "gin.HandlerFunc" {
 		t.Fatal("failed to reflect correct middleware type")
 	}

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -363,6 +363,13 @@ func (api *API) setupRoutes() error {
 			return err
 		}
 	}
+	// ensure we have valid cors configuration
+	var allowedOrigins []string
+	if len(api.cfg.API.Connection.CORS.AllowedOrigin) == 0 {
+		allowedOrigins = middleware.DefaultAllowedOrigins
+	} else {
+		allowedOrigins = api.cfg.API.Connection.CORS.AllowedOrigin
+	}
 	// set up defaults
 	api.r.Use(
 		// allows for automatic xss removal
@@ -373,7 +380,7 @@ func (api *API) setupRoutes() error {
 		// security middleware
 		middleware.NewSecWare(dev),
 		// cors middleware
-		middleware.CORSMiddleware(dev),
+		middleware.CORSMiddleware(dev, allowedOrigins),
 		// request id middleware
 		middleware.RequestID(),
 		// stats middleware

--- a/vendor/github.com/RTradeLtd/config/config.go
+++ b/vendor/github.com/RTradeLtd/config/config.go
@@ -44,4 +44,8 @@ func (t *TemporalConfig) setDefaults() {
 	if t.LogDir == "" {
 		t.LogDir = "/var/log/temporal/"
 	}
+	if len(t.API.Connection.CORS.AllowedOrigin) == 0 {
+		origins := []string{"temporal.cloud", "backup.temporal.cloud"}
+		t.API.Connection.CORS.AllowedOrigin = origins
+	}
 }

--- a/vendor/github.com/RTradeLtd/config/config.go
+++ b/vendor/github.com/RTradeLtd/config/config.go
@@ -45,7 +45,6 @@ func (t *TemporalConfig) setDefaults() {
 		t.LogDir = "/var/log/temporal/"
 	}
 	if len(t.API.Connection.CORS.AllowedOrigin) == 0 {
-		origins := []string{"temporal.cloud", "backup.temporal.cloud"}
-		t.API.Connection.CORS.AllowedOrigin = origins
+		t.API.Connection.CORS.AllowedOrigin = []string{"temporal.cloud", "backup.temporal.cloud"}
 	}
 }

--- a/vendor/github.com/RTradeLtd/config/config.json
+++ b/vendor/github.com/RTradeLtd/config/config.json
@@ -10,6 +10,12 @@
 				"ip": "",
 				"port": ""
 			},
+			"cords": {
+				"allowed_origins": [
+					"temporal.cloud",
+					"backup.temporal.cloud"
+				]
+			},
 			"limit": ""
 		},
 		"jwt": {
@@ -40,7 +46,16 @@
 				"cert_path": "",
 				"key_file": ""
 			},
-			"auth_key": ""
+			"auth_key": "",
+			"options": {
+				"engine": {
+					"store_path": "",
+					"queue": {
+						"rate": 0,
+						"batch": 0
+					}
+				}
+			}
 		},
 		"nexus": {
 			"host": "",
@@ -65,6 +80,16 @@
 			"pass": ""
 		},
 		"krab": {
+			"url": "",
+			"TLS": {
+				"cert_path": "",
+				"key_file": ""
+			},
+			"auth_key": "",
+			"log_file": "",
+			"keystore_password": ""
+		},
+		"krab_fallback": {
 			"url": "",
 			"TLS": {
 				"cert_path": "",

--- a/vendor/github.com/RTradeLtd/config/types.go
+++ b/vendor/github.com/RTradeLtd/config/types.go
@@ -31,6 +31,9 @@ type API struct {
 			IP   string `json:"ip"`
 			Port string `json:"port"`
 		} `json:"prometheus"`
+		CORS struct {
+			AllowedOrigin []string `json:"allowed_origins"`
+		} `json:"cords"`
 		// define the maximum number of people allowed to connect to the API
 		Limit string `json:"limit"`
 	} `json:"connection"`

--- a/vendor/gx/ipfs/QmdBzoMxsBpojBfN1cv5GnKtB7sfYBMoLH7p9qSyEVYXcu/refmt/.gopath/self
+++ b/vendor/gx/ipfs/QmdBzoMxsBpojBfN1cv5GnKtB7sfYBMoLH7p9qSyEVYXcu/refmt/.gopath/self
@@ -1,0 +1,1 @@
+src/github.com/polydawn/refmt


### PR DESCRIPTION
## :construction_worker: Purpose
Instead of having to update the cors allowed origins and recompile, provide it with the config file.
Needs https://github.com/RTradeLtd/config/pull/25 merged first

## :rocket: Changes
* When building the api middleware, check to see if CORS have been provided, otherwise use sane defaults.
* When loading the CORS middleware, we provide the origins we want to allow


## :warning: Breaking Changes
None

