### PR TITLE
Fix Timeouts When Virus Scanning Directory Uploads

### DIFF
--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -354,7 +354,7 @@ func (api *API) uploadDirectory(c *gin.Context) {
 	if err := z.Close(); err != nil {
 		// remove file if this fails
 		os.Remove(destPathZip)
-		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
+		api.LogError(c, err, "an error occurred while processing your request")(http.StatusInternalServerError)
 		return
 	}
 	// ensure they have enough remaining data to cover upload

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -316,7 +316,7 @@ func (api *API) uploadDirectory(c *gin.Context) {
 		return
 	}
 	if err := api.clam.Scan(fh); err != nil {
-		Fail(c, err)
+		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
 		return
 	}
 	randUtils := utils.GenerateRandomUtils()
@@ -324,12 +324,12 @@ func (api *API) uploadDirectory(c *gin.Context) {
 	destPathZip := fmt.Sprintf("/tmp/%s_%s_%s", username, randString, filename)
 	// save the zip file
 	if err := c.SaveUploadedFile(fileHandler, destPathZip); err != nil {
-		Fail(c, err)
+		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
 		return
 	}
 	z, err := zip.OpenReader(destPathZip)
 	if err != nil {
-		Fail(c, err)
+		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
 		return
 	}
 	// protect against zip bombs
@@ -354,7 +354,7 @@ func (api *API) uploadDirectory(c *gin.Context) {
 	if err := z.Close(); err != nil {
 		// remove file if this fails
 		os.Remove(destPathZip)
-		Fail(c, err)
+		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
 		return
 	}
 	// ensure they have enough remaining data to cover upload

--- a/utils/clammy.go
+++ b/utils/clammy.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"io"
+	"time"
 
 	clamd "github.com/baruwa-enterprise/clamd"
 )
@@ -21,6 +22,12 @@ func NewShell(address string) (*Shell, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 3 connection retry attempts
+	c.SetConnRetries(3)
+	// sleep of 1.25 seconds
+	c.SetConnSleep(1250 * time.Millisecond)
+	// timeout of 2 minutes
+	c.SetConnTimeout(2 * time.Minute)
 	return &Shell{
 		clam: c,
 	}, nil

--- a/utils/clammy.go
+++ b/utils/clammy.go
@@ -26,8 +26,10 @@ func NewShell(address string) (*Shell, error) {
 	c.SetConnRetries(3)
 	// sleep of 1.25 seconds
 	c.SetConnSleep(1250 * time.Millisecond)
-	// timeout of 2 minutes
-	c.SetConnTimeout(2 * time.Minute)
+	// timeout of 10 minutes
+	c.SetConnTimeout(10 * time.Minute)
+	c.SetCmdTimeout(10 * time.Minute)
+
 	return &Shell{
 		clam: c,
 	}, nil


### PR DESCRIPTION
## :construction_worker: Purpose
When uploading a zipped file of a significant size, clamd would timeout and fail.


## :rocket: Changes
* Adjust connection and cmd timeouts for the clamd utility in Temporal
* Make sure to adjust settings on clamd configuration server side


## :warning: Breaking Changes
None

