### PR TITLE
User Management For Private Networks And Access Restrictions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,8 +42,7 @@
   version = "v2.0.0"
 
 [[projects]]
-  branch = "tem-251"
-  digest = "1:978e8ec18293603a7ab4c9b2a2e0076b2d3a934e9dc90a6ba141d84355e51b45"
+  digest = "1:6674c489cb7f11b04dd3d5094d9dc671af054cf3d3c565843cd04a773749a19c"
   name = "github.com/RTradeLtd/database"
   packages = [
     ".",
@@ -51,7 +50,8 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "74c477389cd561e9195b51bd4f4faadb45991fde"
+  revision = "f6f0f577fb34488c891c657c38b0519c10eb8127"
+  version = "v2.2.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,7 +42,8 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:23160898269087a3b78d374257f52ea47b22b13ac1058136c9255347090c8507"
+  branch = "tem-251"
+  digest = "1:978e8ec18293603a7ab4c9b2a2e0076b2d3a934e9dc90a6ba141d84355e51b45"
   name = "github.com/RTradeLtd/database"
   packages = [
     ".",
@@ -50,8 +51,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "601bdaaf3651a2f9c0a015d57fdbdaa130c9bdf7"
-  version = "v2.1.1"
+  revision = "74c477389cd561e9195b51bd4f4faadb45991fde"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@ ignored = ["github.com/karalabe/hid", "github.com/satori/go.uuid", "github.com/i
 
 [[override]]
   name = "github.com/RTradeLtd/database"
-  branch = "tem-251"
+  version = "~v2.2.0"
 
 [[override]]
   name = "github.com/RTradeLtd/rtfs"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,7 +14,7 @@ ignored = ["github.com/karalabe/hid", "github.com/satori/go.uuid", "github.com/i
 
 [[override]]
   name = "github.com/RTradeLtd/database"
-  version = "~v2.1.0"
+  branch = "tem-251"
 
 [[override]]
   name = "github.com/RTradeLtd/rtfs"

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -534,6 +534,11 @@ func (api *API) setupRoutes() error {
 			private.GET("/networks", api.getAuthorizedPrivateNetworks)
 			network := private.Group("/network")
 			{
+				users := network.Group("/users")
+				{
+					users.DELETE("/remove", api.removeUsersFromNetwork)
+					users.POST("/add", api.addUsersToNetwork)
+				}
 				network.GET("/:name", api.getIPFSPrivateNetworkByName)
 				network.POST("/new", api.createIPFSNetwork)
 				network.POST("/stop", api.stopIPFSPrivateNetwork)

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -539,6 +539,10 @@ func (api *API) setupRoutes() error {
 					users.DELETE("/remove", api.removeUsersFromNetwork)
 					users.POST("/add", api.addUsersToNetwork)
 				}
+				owners := network.Group("/owners")
+				{
+					owners.POST("/add", api.addOwnersToNetwork)
+				}
 				network.GET("/:name", api.getIPFSPrivateNetworkByName)
 				network.POST("/new", api.createIPFSNetwork)
 				network.POST("/stop", api.stopIPFSPrivateNetwork)

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -44,7 +44,7 @@ func (api *API) createIPFSNetwork(c *gin.Context) {
 		users = append(users, username)
 	}
 	// create the network in our database
-	network, err := api.nm.CreateHostedPrivateNetwork(networkName, swarmKey, bPeers, models.NetworkAccessOptions{Users: users})
+	network, err := api.nm.CreateHostedPrivateNetwork(networkName, swarmKey, bPeers, models.NetworkAccessOptions{Users: users, Owner: username})
 	if err != nil {
 		api.LogError(c, err, eh.NetworkCreationError)(http.StatusBadRequest)
 		return

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -388,7 +388,7 @@ func (api *API) removeUsersFromNetwork(c *gin.Context) {
 		return
 	}
 	var (
-		usersToRemove map[string]bool
+		usersToRemove = make(map[string]bool)
 		newUsers      []string
 	)
 	for _, user := range users {

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -452,13 +452,6 @@ func (api *API) addOwnersToNetwork(c *gin.Context) {
 		api.LogError(c, err, eh.NetworkSearchError)(http.StatusInternalServerError)
 		return
 	}
-	for _, v := range network.Users {
-		if err = api.um.RemoveIPFSNetworkForUser(v, networkName); err != nil {
-			api.LogError(c, err, "failed to remove network from users")(http.StatusBadRequest)
-			return
-		}
-	}
-
 	network.Owners = append(network.Owners, owners...)
 	if err := api.nm.UpdateNetworkByName(networkName, map[string]interface{}{"owners": network.Owners}); err != nil {
 		api.LogError(c, err, "failed to update network owners")

--- a/api/v2/routes_rtfsp_management.go
+++ b/api/v2/routes_rtfsp_management.go
@@ -111,7 +111,6 @@ func (api *API) startIPFSPrivateNetwork(c *gin.Context) {
 		Network: networkName}); err != nil {
 		api.LogError(c, err, "failed to start network")(http.StatusBadRequest)
 		return
-		return
 	}
 	// log and return
 	logger.Info("network started")

--- a/api/v2/rtfsp_management_test.go
+++ b/api/v2/rtfsp_management_test.go
@@ -1,0 +1,68 @@
+package v2
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/RTradeLtd/database/models"
+
+	"github.com/RTradeLtd/Temporal/mocks"
+	"github.com/RTradeLtd/config"
+)
+
+func Test_API_Routes_IPFS_Private_User_Management(t *testing.T) {
+	// load configuration
+	cfg, err := config.LoadConfig("../../testenv/config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := loadDatabase(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// setup fake mock clients
+	fakeLens := &mocks.FakeLensV2Client{}
+	fakeOrch := &mocks.FakeServiceClient{}
+	fakeSigner := &mocks.FakeSignerClient{}
+
+	api, _, err := setupAPI(fakeLens, fakeOrch, fakeSigner, cfg, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := api.um.NewUserAccount("testaccount2323", "password123", "example@example.org"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := api.nm.CreateHostedPrivateNetwork(
+		"testnetworkdude",
+		"swarmkey",
+		nil,
+		models.NetworkAccessOptions{Owner: "testuser", Users: []string{"testuser"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	var apiResp = apiResponse{}
+	urlValues := url.Values{}
+	urlValues.Add("network_name", "testnetworkdude")
+	urlValues.Add("users", "testaccount2323")
+	urlValues.Add("owners", "testaccount2323")
+	// test adding a user
+	if err := sendRequest(
+		api, "POST", "/v2/ipfs/private/network/users/add", 200, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// test removing a user
+	if err := sendRequest(
+		api, "DELETE", "/v2/ipfs/private/network/users/remove", 200, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// test adding an owner
+	if err := sendRequest(
+		api, "POST", "/v2/ipfs/private/network/owners/add", 200, nil, urlValues, &apiResp,
+	); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/vendor/github.com/RTradeLtd/database/models/hosted_network.go
+++ b/vendor/github.com/RTradeLtd/database/models/hosted_network.go
@@ -43,6 +43,9 @@ type HostedNetwork struct {
 	ResourcesDiskGB   int
 	ResourcesMemoryGB int
 
+	// Owner is the creator of the private network, and is allowed to invoke
+	// administrative commands, such as network destruction.
+	Owner string `gorm:"type:text"`
 	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }
@@ -129,6 +132,7 @@ func (im *HostedNetworkManager) GetOfflineNetworks(disabled bool) ([]*HostedNetw
 
 // NetworkAccessOptions configures access to a hosted private network
 type NetworkAccessOptions struct {
+	Owner            string
 	Users            []string
 	APIAllowedOrigin string
 	PublicGateway    bool
@@ -187,9 +191,10 @@ func (im *HostedNetworkManager) CreateHostedPrivateNetwork(
 		for _, v := range access.Users {
 			pnet.Users = append(pnet.Users, v)
 		}
-	} else {
-		pnet.Users = append(pnet.Users, AdminAddress)
 	}
+
+	// set the owner of the network
+	pnet.Owner = access.Owner
 
 	// assign misc details
 	pnet.Name = name

--- a/vendor/github.com/RTradeLtd/database/models/hosted_network.go
+++ b/vendor/github.com/RTradeLtd/database/models/hosted_network.go
@@ -45,7 +45,7 @@ type HostedNetwork struct {
 
 	// Owner is the creator of the private network, and is allowed to invoke
 	// administrative commands, such as network destruction.
-	Owner string `gorm:"type:text"`
+	Owners pq.StringArray `gorm:"type:text[]"`
 	// Users allowed to control this node. Includes API access.
 	Users pq.StringArray `gorm:"type:text[]"` // these are the users to which this IPFS network connection applies to specified by eth address
 }
@@ -194,7 +194,7 @@ func (im *HostedNetworkManager) CreateHostedPrivateNetwork(
 	}
 
 	// set the owner of the network
-	pnet.Owner = access.Owner
+	pnet.Owners = []string{access.Owner}
 
 	// assign misc details
 	pnet.Name = name


### PR DESCRIPTION
## :construction_worker: Purpose
If a user was authorized to access a private network they could invoke destructive commands such as destroying the network. Additionally, you were unable to modify authorized users after the network is created.

Needs [database/33](https://github.com/RTradeLtd/database/pull/33) to be merged first

## :rocket: Changes
* Add API call to add+remove user(s) to/from network access list
* Restrict all network management commands to be access by the owner only
* Allow for setting multiple owners

## :warning: Breaking Changes


