### PR TITLE
docs: fix docker hub link

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -128,7 +128,7 @@ $> curl https://raw.githubusercontent.com/RTradeLtd/Temporal/master/temporal.yml
 $> docker-compose -f temporal.yml up
 ```
 
-Temporal的Docker镜像获取地址：[Docker Hub](https://cloud.docker.com/u/rtradetech/repository/docker/rtradetech/temporal).
+Temporal的Docker镜像获取地址：[Docker Hub](https://hub.docker.com/r/rtradetech/temporal).
 
 更多细节请参考`temporal.yml` 文档.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $> curl https://raw.githubusercontent.com/RTradeLtd/Temporal/master/temporal.yml
 $> docker-compose -f temporal.yml up
 ```
 
-The standalone Temporal Docker image is available on [Docker Hub](https://cloud.docker.com/u/rtradetech/repository/docker/rtradetech/temporal).
+The standalone Temporal Docker image is available on [Docker Hub](https://hub.docker.com/r/rtradetech/temporal).
 
 Refer to the `temporal.yml` documentation for more details.
 


### PR DESCRIPTION
## :construction_worker: Purpose
The old link goes to the docker cloud build server, which requires access permissions to view. This is the correct public link for docker hub images.


## :rocket: Changes
Docker link in readme and Chinese translation.


## :warning: Breaking Changes
None

