### PR TITLE
docs: add WIP readme overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,10 @@ ls:
 
 # Installs Temporal to GOBIN
 .PHONY: install
-install: cli
+install: setup cli
 	@echo "=================== installing Temporal CLI ==================="
-	go install -ldflags "-X main.Version=$(TEMPORALVERSION)" ./cmd/temporal
+	sudo cp ./temporal /bin/temporal
+	/bin/temporal -config ${HOME}/temporal-config.json init
 	@echo "===================          done           ==================="
 
 # Run simple checks
@@ -176,7 +177,7 @@ api-user:
 api-admin:
 	go run cmd/temporal/main.go $(TEMPORALDEVFLAGS) admin $(USER)
 
-.PHOYN: setup
+.PHONY: setup
 setup:
 	git submodule update --init
 	go mod download

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEMPORALDEVFLAGS=-config ./testenv/config.json -db.no_ssl -dev
 IPFSVERSION=v0.4.19
 TESTKEYNAME=admin-key
 
-all: check cli
+all: check install
 
 # Build temporal if binary is not already present
 temporal:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ls:
 .PHONY: install
 install: cli
 	@echo "=================== installing Temporal CLI ==================="
-	go install -ldflags "-X main.Version=$(TEMPORALVERSION)" cmd/temporal
+	go install -ldflags "-X main.Version=$(TEMPORALVERSION)" ./cmd/temporal
 	@echo "===================          done           ==================="
 
 # Run simple checks

--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,9 @@ api-user:
 .PHONY: api-admin
 api-admin:
 	go run cmd/temporal/main.go $(TEMPORALDEVFLAGS) admin $(USER)
+
+.PHOYN: setup
+setup:
+	git submodule update --init
+	go mod download
+	( cd testenv ; go mod download )

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ One of the big concerns with IPFS, and even cloud data storage in general is enc
 
 ## Usage and Features
 
-Before attempting to use Temporal you will need to install it. Even if you are going to be using our dockerized tooling, an install of Temporal is needed primarily for configuration file initialization, and running of a [kaas](https://github.com/RTradeLtd/kaas) grpc server. 
+Before attempting to use Temporal you will need to install it. Even if you are going to be using our dockerized tooling, an install of Temporal is needed primarily for configuration file initialization.
 
-Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up.
+Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up. Should you want to read about our payment processing backedn see [RTradeLtd/Pay](https://github.com/RTradeLtd/Pay)
 
 The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to a partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manually management of user credits. 
 
@@ -237,7 +237,7 @@ Our API documentation has been redesigned to use slate, hosted through IPFS. The
 
 ### Supported Technologies
 
-Currently we fully support all non-experimental IPFS and IPNS feature-sets. Features like UnixFS, MFS are on-hold until their specs, and implementations become more stable and usable within production environments. Additional protocols like STORJ, and SWARM will be added, fully supporting public+private integrations. At the moment, the next planned protocol is STORJ, with alpha integration expected near the of January/February 2019.
+Currently we fully support all non-experimental IPFS and IPNS feature-sets. Features like UnixFS, MFS are on-hold until their specs, and implementations become more stable and usable within production environments.
 
 ### System Monitoring
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ Before attempting to use Temporal you will need to install it. Even if you are g
 
 Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up.
 
-The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities.
+The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to a partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manually management of user credits. 
+
+For details on organization management, and the entire API please consult  our [api docs](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud/account.html#organization-management).
 
 ### Installing Temporal
 
@@ -133,7 +135,7 @@ The first thing you need to do is install Temporal, for which there are two main
 
 This is quite a bit more complicated, and requires things like a proper golang version installed. Unless you have specific reason to compile from source, it is recommended you skip this and stick with download the pre-built binaries.
 
-If you do want to download and build from source, be-aware the download process can take *A LONG TIME* depending on your bandwidth and internet speed. Usually it takes up to 30 minutes.
+If you do want to download and build from source, be aware the download process can take *A LONG TIME* depending on your bandwidth and internet speed. Usually it takes up to 30 minutes.
 
 Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). This will ensure you have the proper go version, download the github repository, compile the cli, and install it. The main settings, such as workdir and binary install location are configurable, but come with sensible defaults. Alternatively here's a copy of the script
 
@@ -143,8 +145,6 @@ Should you still want to do this, download the [install_from_source.sh script](.
 # setup install variabels
 GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
 WORKDIR="/tmp/temporal-workdir"
-BINARY_DIR="/usr/local/bin"
-
 # handle golagn version detection
 if [[ "$GOVERSION" -lt 11 ]]; then
     echo "[ERROR] golang is less than 1.11 and will produce errors"
@@ -162,9 +162,7 @@ cd Temporal
 # initialize submodules, and download all dependencies
 make setup
 # make cli binary
-make cli
-# copy the cli binary to /usr/bin
-sudo cp ./temporal "$BINARY_DIR"
+make install
 ```
 
 **Downloading Pre-Built Binaries:**
@@ -203,22 +201,23 @@ It is **extremely** important you keep this in a directory that is only accessib
 
 For an example bare-minium configuration file, check out [testenv/config.json](https://github.com/RTradeLtd/testenv/blob/master/config.json)
 
-### Setup Without Docker
+### Manual Setup
 
-Now that you've got the CLI installed and a configuration file generated, you can continue with the setup procedure.
+This exact process will vary a bit depending on the environment you are installing Temporal in. At the very least you are required to use Postgres, and RabbitMQ. The operating systems you install those, and the supplementary services on is entirely up to you, but we recommend using Ubuntu 18.04LTS.
 
-### Setup With Docker
+For the manual setup process using Ubuntu 18.04LTS consult our [confluence page](https://rtradetechnologies.atlassian.net/wiki/spaces/TEM/pages/55083603/Installing+Temporal+In+Production). For the manual setup process using other operating systems, please read the confluence page and adjust the commands as needed.
 
-Once you have a `config.json` set up (a template can be generated using `temporal init`), you can run the following commands to use docker-compose to spin up Temporal:
+### Dockerized Setup
+
+The dockerized setup process is generally much easier, however it requires manually spinning up Postgres and RabbitMQ nodes either via docker, or manually. Additionally you'll need to make sure that you copy the config file over to the appropriate locations for the docker containers to access. The `temporal.yml` docker-compose file has more information about this, so please consult that.
+
+To download the docker-compose file:
 
 ```shell
 $> curl https://raw.githubusercontent.com/RTradeLtd/Temporal/master/temporal.yml --output temporal.yml
-$> docker-compose -f temporal.yml up
 ```
 
 The standalone Temporal Docker image is available on [Docker Hub](https://hub.docker.com/r/rtradetech/temporal).
-
-Refer to the `temporal.yml` documentation for more details.
 
 ### API Documentation
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@ One of the big concerns with IPFS, and even cloud data storage in general is enc
 
 ## Usage and Features
 
-Before attempting to use Temporal you will need to install it. Even if you are going to be using our dockerized tooling, an install of Temporal is needed.
+Before attempting to use Temporal you will need to install it. Even if you are going to be using our dockerized tooling, an install of Temporal is needed primarily for configuration file initialization, and running of a [kaas](https://github.com/RTradeLtd/kaas) grpc server. 
+
+Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up.
+
+The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities.
 
 ### Installing Temporal
 
@@ -131,7 +135,7 @@ This is quite a bit more complicated, and requires things like a proper golang v
 
 If you do want to download and build from source, be-aware the download process can take *A LONG TIME* depending on your bandwidth and internet speed. Usually it takes up to 30 minutes.
 
-Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). Alternatively here's the script
+Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). This will ensure you have the proper go version, download the github repository, compile the cli, and install it. The main settings, such as workdir and binary install location are configurable, but come with sensible defaults. Alternatively here's a copy of the script
 
 ```bash
 #! /bin/bash
@@ -140,6 +144,7 @@ Should you still want to do this, download the [install_from_source.sh script](.
 GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
 WORKDIR="/tmp/temporal-workdir"
 BINARY_DIR="/usr/local/bin"
+
 # handle golagn version detection
 if [[ "$GOVERSION" -lt 11 ]]; then
     echo "[ERROR] golang is less than 1.11 and will produce errors"
@@ -159,7 +164,7 @@ make setup
 # make cli binary
 make cli
 # copy the cli binary to /usr/bin
-sudo cp ./temporal /usr/local/bin
+sudo cp ./temporal "$BINARY_DIR"
 ```
 
 **Downloading Pre-Built Binaries:**
@@ -170,7 +175,7 @@ Download a binary for your appropriate platform, additionally you can download s
 
 You'll then want to copy the pre-built binary over to anywhere in your `PATH` environment variable.
 
-Example
+Example for downloading and installing the Linux version:
 
 ```bash
 # download the binary
@@ -190,12 +195,17 @@ if [[ "$CK_HASH" == "$DL_HASH" ]]; then  echo && sudo cp temporal-v2.2.7-linux-a
 
 After downloading Temporal, regardless of your setup process you will need a configuration file. If you want to generate a config file at `/tmp/config.json` run the following command:
 ```
-temporal -config /tmp/config.json init
+temporal -config /home/youruser/config.json init
 ```
 **Alternatively you can set the environmetn variable `CONFIG_DAG` and `temporal init`, along with *all other commands* will read from this location. It is recommended that you do this as it makes using the cli a lot easier**
 
+It is **extremely** important you keep this in a directory that is only accessible to the users required to run the servivce as it contains usernames and passwords to key pieces of Temporal's infrastructure.
+
+For an example bare-minium configuration file, check out [testenv/config.json](https://github.com/RTradeLtd/testenv/blob/master/config.json)
 
 ### Setup Without Docker
+
+Now that you've got the CLI installed and a configuration file generated, you can continue with the setup procedure.
 
 ### Setup With Docker
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,49 @@ One of the big concerns with IPFS, and even cloud data storage in general is enc
 
 ## Usage and Features
 
-### Spinning up a Node
+Before attempting to use Temporal you will need to install it. Even if you are going to be using our dockerized tooling, an install of Temporal is needed.
+
+### Installing Temporal
+
+The first thing you need to do is install Temporal, for which there are two main options:
+
+1) Compiling from source
+2) Downloading pre-built binaries
+
+**Compiling From Source:**
+
+This is quite a bit more complicated, and requires things like a proper golang version installed. Unless you have specific reason to compile from source, it is recommended you skip this and stick with download the pre-built binaries.
+
+**Downloading Pre-Built Binaries:**
+
+To download pre-built binaries, currently available for Linux and Mac OSX platforms, head on over to our [github releases page](https://github.com/RTradeLtd/Temporal/releases/latest).
+
+Download a binary for your appropriate platform, additionally you can download sha256 checksums of the released binaries for post-download integrity verification. 
+
+You'll then want to copy the pre-built binary over to anywhere in your `PATH` environment variable.
+
+Example
+
+```bash
+# download the binary
+wget https://github.com/RTradeLtd/Temporal/releases/download/v2.2.7/temporal-v2.2.7-linux-amd64
+# download the binary checksum
+wget https://github.com/RTradeLtd/Temporal/releases/download/v2.2.7/temporal-v2.2.7-linux-amd64.sha256
+# store downloaded checksum output
+CK_HASH=$(cat *.sha256  | awk '{print $1}')
+# calculate sha256 checksum of downloaded binary
+DL_HASH=$(sha256sum temporal-v2.2.7-linux-amd64 | awk '{print $1}')
+# compare checksums, and copy file to `PATH` if ok
+# if this doesn't show ok then your binary is corrupted or has been tampered with
+if [[ "$CK_HASH" == "$DL_HASH" ]]; then  echo && sudo cp temporal-v2.2.7-linux-amd64 /usr/local/bin; fi
+```
+
+
+
+
+### Setup Without Docker
+
+### Setup With Docker
 
 Once you have a `config.json` set up (a template can be generated using `temporal init`), you can run the following commands to use docker-compose to spin up Temporal:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This is quite a bit more complicated, and requires things like a proper golang v
 
 If you do want to download and build from source, be aware the download process can take *A LONG TIME* depending on your bandwidth and internet speed. Usually it takes up to 30 minutes.
 
-Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). This will ensure you have the proper go version, download the github repository, compile the cli, and install it. The main settings, such as workdir and binary install location are configurable, but come with sensible defaults. Alternatively here's a copy of the script
+Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). This will ensure you have the proper go version, download the github repository, compile the cli, and install it to `/bin/temporal`.
 
 ```bash
 #! /bin/bash

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Before attempting to use Temporal you will need to install it. Even if you are g
 
 Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up. Should you want to read about our payment processing backedn see [RTradeLtd/Pay](https://github.com/RTradeLtd/Pay)
 
-The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to a partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manually management of user credits. 
+The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manual management of user credits. 
 
 For details on organization management, and the entire API please consult  our [api docs](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud/account.html#organization-management).
 
@@ -186,20 +186,22 @@ CK_HASH=$(cat *.sha256  | awk '{print $1}')
 DL_HASH=$(sha256sum temporal-v2.2.7-linux-amd64 | awk '{print $1}')
 # compare checksums, and copy file to `PATH` if ok
 # if this doesn't show ok then your binary is corrupted or has been tampered with
-if [[ "$CK_HASH" == "$DL_HASH" ]]; then  echo && sudo cp temporal-v2.2.7-linux-amd64 /usr/local/bin; fi
+if [[ "$CK_HASH" == "$DL_HASH" ]]; then  echo "ok" && sudo cp temporal-v2.2.7-linux-amd64 /usr/local/bin; fi
 ```
 
 ### Configuration Initialization
 
-After downloading Temporal, regardless of your setup process you will need a configuration file. If you want to generate a config file at `/tmp/config.json` run the following command:
+After downloading Temporal, regardless of your setup process you will need a configuration file. To generate a config file at `/home/doggo/config.json` run the following command:
 ```
-temporal -config /home/youruser/config.json init
+temporal -config /home/doggo/config.json init
 ```
-**Alternatively you can set the environmetn variable `CONFIG_DAG` and `temporal init`, along with *all other commands* will read from this location. It is recommended that you do this as it makes using the cli a lot easier**
+**Alternatively you can set the environment variable `CONFIG_DAG` and `temporal init`, along with *all other commands* will read from this location. It is recommended that you do this as it makes using the cli a lot easier**
 
 It is **extremely** important you keep this in a directory that is only accessible to the users required to run the servivce as it contains usernames and passwords to key pieces of Temporal's infrastructure.
 
 For an example bare-minium configuration file, check out [testenv/config.json](https://github.com/RTradeLtd/testenv/blob/master/config.json)
+
+Note that if you did the install from source method, you will already have a config file in your home directory called `temporal-config.json`.
 
 ### Manual Setup
 
@@ -209,7 +211,7 @@ For the manual setup process using Ubuntu 18.04LTS consult our [confluence page]
 
 ### Dockerized Setup
 
-The dockerized setup process is generally much easier, however it requires manually spinning up Postgres and RabbitMQ nodes either via docker, or manually. Additionally you'll need to make sure that you copy the config file over to the appropriate locations for the docker containers to access. The `temporal.yml` docker-compose file has more information about this, so please consult that.
+The dockerized setup process is generally much easier, however it requires manually spinning up Postgres and RabbitMQ nodes either via docker, or manually. Additionally you'll need to make sure that you copy the config file over to the appropriate locations for the docker containers to access. For instructions on that, and for usage of docker-compose please consult the `temporal.yml` docker-composefile.
 
 To download the docker-compose file:
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Note that if you did the install from source method, you will already have a con
 
 This exact process will vary a bit depending on the environment you are installing Temporal in. At the very least you are required to use Postgres, and RabbitMQ. The operating systems you install those, and the supplementary services on is entirely up to you, but we recommend using Ubuntu 18.04LTS. For instructions on setting up Postgres see their [documentation](https://www.postgresql.org/docs/10/tutorial-start.html). For instructions on setting up RabbitMQ consult their [documentation](https://www.rabbitmq.com/download.html). We do go into a bit of a setup process for RabbitMQ in the confluence page linked below, although it is always good to read official sources.
 
-For the manual setup process using Ubuntu 18.04LTS consult our [confluence page](https://rtradetechnologies.atlassian.net/wiki/spaces/TEM/pages/55083603/Installing+Temporal+In+Production). For the manual setup process using other operating systems, please read the confluence page and adjust the commands as needed.
+For the manual setup process using Ubuntu 18.04LTS consult our [confluence page](https://rtradetechnologies.atlassian.net/wiki/spaces/TEM/pages/55083603/Installing+Temporal+In+Production). For the manual setup process using other operating systems, please read the confluence page and adjust the commands as needed. The confluence page covers filling out the needed parts of the configuration file.
 
 ### Dockerized Setup
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,39 @@ The first thing you need to do is install Temporal, for which there are two main
 
 This is quite a bit more complicated, and requires things like a proper golang version installed. Unless you have specific reason to compile from source, it is recommended you skip this and stick with download the pre-built binaries.
 
+If you do want to download and build from source, be-aware the download process can take *A LONG TIME* depending on your bandwidth and internet speed. Usually it takes up to 30 minutes.
+
+Should you still want to do this, download the [install_from_source.sh script](./setup/scripts/misc/install_from_source.sh). Alternatively here's the script
+
+```bash
+#! /bin/bash
+
+# setup install variabels
+GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
+WORKDIR="/tmp/temporal-workdir"
+BINARY_DIR="/usr/local/bin"
+# handle golagn version detection
+if [[ "$GOVERSION" -lt 11 ]]; then
+    echo "[ERROR] golang is less than 1.11 and will produce errors"
+    exit 1
+fi
+if [[ "$GOVERSION" -lt 12 ]]; then
+    echo "[WARN] detected golang version is less than 1.12 and may produce errors"
+fi
+# create working directory
+mkdir "$WORKDIR"
+cd "$WORKDIR"
+# download temporal
+git clone https://github.com/RTradeLtd/Temporal.git
+cd Temporal
+# initialize submodules, and download all dependencies
+make setup
+# make cli binary
+make cli
+# copy the cli binary to /usr/bin
+sudo cp ./temporal /usr/local/bin
+```
+
 **Downloading Pre-Built Binaries:**
 
 To download pre-built binaries, currently available for Linux and Mac OSX platforms, head on over to our [github releases page](https://github.com/RTradeLtd/Temporal/releases/latest).
@@ -153,7 +186,13 @@ DL_HASH=$(sha256sum temporal-v2.2.7-linux-amd64 | awk '{print $1}')
 if [[ "$CK_HASH" == "$DL_HASH" ]]; then  echo && sudo cp temporal-v2.2.7-linux-amd64 /usr/local/bin; fi
 ```
 
+### Configuration Initialization
 
+After downloading Temporal, regardless of your setup process you will need a configuration file. If you want to generate a config file at `/tmp/config.json` run the following command:
+```
+temporal -config /tmp/config.json init
+```
+**Alternatively you can set the environmetn variable `CONFIG_DAG` and `temporal init`, along with *all other commands* will read from this location. It is recommended that you do this as it makes using the cli a lot easier**
 
 
 ### Setup Without Docker

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Before attempting to use Temporal you will need to install it. Even if you are g
 
 Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up. Should you want to read about our payment processing backedn see [RTradeLtd/Pay](https://github.com/RTradeLtd/Pay)
 
+For a minimal setup you do not need to configure any of this, and can leave that part of the config file alone as it will be ignored. It is worth mentioning though that running a minimal setup doesn't disable the payment API calls, so if someone were to place these API calls against your minimal setup it might result in unexpected errors, such as panics. If this happens please open a bug report on github.
+
 The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manual management of user credits. 
 
 For details on organization management, and the entire API please consult  our [api docs](https://gateway.temporal.cloud/ipns/docs.api.temporal.cloud/account.html#organization-management).

--- a/README.md
+++ b/README.md
@@ -211,12 +211,22 @@ For the manual setup process using Ubuntu 18.04LTS consult our [confluence page]
 
 ### Dockerized Setup
 
-The dockerized setup process is generally much easier, however it requires manually spinning up Postgres and RabbitMQ nodes either via docker, or manually. Additionally you'll need to make sure that you copy the config file over to the appropriate locations for the docker containers to access. For instructions on that, and for usage of docker-compose please consult the `temporal.yml` docker-composefile.
+The docker-compose file defaults to placing everything in `/data/temporal`, so for this part of the tutorial we will be using that particular default. If you want to override it you can use the `BASE=/path/to/base` variable.
+
+First off you'll need to copy the Temporal config file to `/data/temporal/config.json` then you can proceed with the rest of the steps. Ensure that the config file is pointing to a postgresql and rabbitmq docker contianer, or server that is reachable by the docker containers that will be started up.
+
+Additionally you'll need to make sure that any tls certificates, and files needed by the api service are appropriately located within `/data/temporal`.
 
 To download the docker-compose file:
 
 ```shell
 $> curl https://raw.githubusercontent.com/RTradeLtd/Temporal/master/temporal.yml --output temporal.yml
+```
+
+Then afterwards to execute the docker-compose file using the latest version of the temporal docker image run
+
+```shell
+$> env TEMPORAL=latest docker-compose -f temporal.yml up
 ```
 
 The standalone Temporal Docker image is available on [Docker Hub](https://hub.docker.com/r/rtradetech/temporal).

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Before attempting to use Temporal you will need to install it. Even if you are g
 
 Please note that a full-blown Temporal instance including the payment processing backend can take awhile, and requires an API key for [ChainRider](https://chainrider.io/) as well as a fully synced [geth node](https://github.com/ethereum/go-ethereum), and [bchd node](https://github.com/gcash/bchd). We will *not* be covering the setup of either chainrider, geth, and bchd, please consult appropriate documentation for setting those up. Should you want to read about our payment processing backedn see [RTradeLtd/Pay](https://github.com/RTradeLtd/Pay)
 
-For a minimal setup you do not need to configure any of this, and can leave that part of the config file alone as it will be ignored. It is worth mentioning though that running a minimal setup doesn't disable the payment API calls, so if someone were to place these API calls against your minimal setup it might result in unexpected errors, such as panics. If this happens please open a bug report on github.
+For a minimal setup you do not need to configure anything related to the aforementioned topics (geth, pay, bch, etc..). It is worth mentioning though that running a minimal setup doesn't disable the payment API calls, so if someone were to place these API calls against your minimal setup it might result in unexpected errors, such as panics. If this happens please open a bug report on github.
 
 The rest of this usage documentation will be covering a bare-minimum Temporal setup which does not include any payment processing capabilities. Thus you will not be able to "purchase credits" the remedy to this is to manually alter user account balances, or promote a user to partner tier, registering an organization, and then creating all new users under that organization. This effectively side-steps the billing process, and requires no manual management of user credits. 
 
@@ -207,7 +207,7 @@ Note that if you did the install from source method, you will already have a con
 
 ### Manual Setup
 
-This exact process will vary a bit depending on the environment you are installing Temporal in. At the very least you are required to use Postgres, and RabbitMQ. The operating systems you install those, and the supplementary services on is entirely up to you, but we recommend using Ubuntu 18.04LTS.
+This exact process will vary a bit depending on the environment you are installing Temporal in. At the very least you are required to use Postgres, and RabbitMQ. The operating systems you install those, and the supplementary services on is entirely up to you, but we recommend using Ubuntu 18.04LTS. For instructions on setting up Postgres see their [documentation](https://www.postgresql.org/docs/10/tutorial-start.html). For instructions on setting up RabbitMQ consult their [documentation](https://www.rabbitmq.com/download.html). We do go into a bit of a setup process for RabbitMQ in the confluence page linked below, although it is always good to read official sources.
 
 For the manual setup process using Ubuntu 18.04LTS consult our [confluence page](https://rtradetechnologies.atlassian.net/wiki/spaces/TEM/pages/55083603/Installing+Temporal+In+Production). For the manual setup process using other operating systems, please read the confluence page and adjust the commands as needed.
 

--- a/setup/scripts/misc/install_from_source.sh
+++ b/setup/scripts/misc/install_from_source.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+# setup install variabels
+GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
+WORKDIR="/tmp/temporal-workdir"
+BINARY_DIR="/usr/local/bin"
+# handle golagn version detection
+if [[ "$GOVERSION" -lt 11 ]]; then
+    echo "[ERROR] golang is less than 1.11 and will produce errors"
+    exit 1
+fi
+if [[ "$GOVERSION" -lt 12 ]]; then
+    echo "[WARN] detected golang version is less than 1.12 and may produce errors"
+fi
+# create working directory
+mkdir "$WORKDIR"
+cd "$WORKDIR"
+# download temporal
+git clone https://github.com/RTradeLtd/Temporal.git
+cd Temporal
+# initialize submodules, and download all dependencies
+make setup
+# make cli binary
+make cli
+# copy the cli binary to /usr/bin
+sudo cp ./temporal /usr/local/bin

--- a/setup/scripts/misc/install_from_source.sh
+++ b/setup/scripts/misc/install_from_source.sh
@@ -3,8 +3,6 @@
 # setup install variabels
 GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
 WORKDIR="/tmp/temporal-workdir"
-BINARY_DIR="/usr/local/bin"
-
 # handle golagn version detection
 if [[ "$GOVERSION" -lt 11 ]]; then
     echo "[ERROR] golang is less than 1.11 and will produce errors"
@@ -22,6 +20,4 @@ cd Temporal
 # initialize submodules, and download all dependencies
 make setup
 # make cli binary
-make cli
-# copy the cli binary to /usr/bin
-sudo cp ./temporal "$BINARY_DIR"
+make install

--- a/setup/scripts/misc/install_from_source.sh
+++ b/setup/scripts/misc/install_from_source.sh
@@ -4,6 +4,7 @@
 GOVERSION=$(go version | awk '{print $3}' | tr -d "go" | awk -F "." '{print $2}')
 WORKDIR="/tmp/temporal-workdir"
 BINARY_DIR="/usr/local/bin"
+
 # handle golagn version detection
 if [[ "$GOVERSION" -lt 11 ]]; then
     echo "[ERROR] golang is less than 1.11 and will produce errors"
@@ -23,4 +24,4 @@ make setup
 # make cli binary
 make cli
 # copy the cli binary to /usr/bin
-sudo cp ./temporal /usr/local/bin
+sudo cp ./temporal "$BINARY_DIR"

--- a/temporal.yml
+++ b/temporal.yml
@@ -86,17 +86,3 @@ services:
       - 9096:9096
     volumes:
       - ${BASE}/data/ipfs-cluster:/data/ipfs-cluster
-
-  postgres:
-    image: postgres
-    ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_DB: "temporal"
-      POSTGRES_USER: "postgres"
-      POSTGRES_PASSWORD: "password123"
-
-  rabbitmq:
-    image: rabbitmq
-    ports:
-      - "5672:5672"

--- a/temporal.yml
+++ b/temporal.yml
@@ -67,8 +67,8 @@ services:
       - ${BASE}/data/temporal:/data/temporal
 
   ipfs:
-    image: ipfs/go-ipfs:v0.4.20
-    command: daemon --migrate=true --enable-pubsub-experiment
+    image: ipfs/go-ipfs:v0.4.22
+    command: daemon --migrate=true --enable-namesys-pubsub
     ports:
       - 4001:4001
       - 5001:5001
@@ -79,10 +79,24 @@ services:
   ipfs_cluster:
     depends_on: 
       - ipfs
-    image: ipfs/ipfs-cluster:v0.10.1
+    image: ipfs/ipfs-cluster:v0.11.0
     ports:
       - 9094:9094
       - 9095:9095
       - 9096:9096
     volumes:
       - ${BASE}/data/ipfs-cluster:/data/ipfs-cluster
+
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: "temporal"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "password123"
+
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672:5672"

--- a/temporal.yml
+++ b/temporal.yml
@@ -22,49 +22,49 @@ services:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   krab:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: krab
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   queue-email-send:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: queue email-send
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   queue-ipfs-cluster:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: queue ipfs cluster
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   queue-ipfs-ipns-entry:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: queue ipfs ipns-entry
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   queue-ipfs-key-creation:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: queue ipfs key-creation
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   queue-ipfs-pin:
     image: rtradetech/temporal:${TEMPORAL}
     network_mode: "host" # expose all
     command: queue ipfs pin
     volumes:
-      - ${BASE}/data/temporal:/data/temporal
+      - ${BASE}/data/temporal:/temporal
 
   ipfs:
     image: ipfs/go-ipfs:v0.4.22


### PR DESCRIPTION
## :construction_worker: Purpose

The readme was lacking when it comes to setting up Temporal. Closes https://github.com/RTradeLtd/Temporal/issues/389

## :rocket: Changes

* Update the readme with new sections on installing Temporal.
* Adds a script that can be used to build Temporal entirely from source
* Adjusts the location the docker-compose file mounts to in order to be more compatible with where the docker image looks for stuff.
* Update makefile install target

## :warning: Breaking Changes

None
