### PR TITLE
Enable Recording Of File Name Through API

### DIFF
--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -91,6 +91,7 @@ func (api *API) pinHashLocally(c *gin.Context) {
 		HoldTimeInMonths: holdTimeInt,
 		Size:             int64(stats.CumulativeSize),
 		CreditCost:       cost,
+		FileName:         c.PostForm("file_name"),
 	}
 	// sent pin message
 	if err = api.queues.cluster.PublishMessage(qp); err != nil {
@@ -248,6 +249,7 @@ func (api *API) addFile(c *gin.Context) {
 		NetworkName:      "public",
 		UserName:         username,
 		HoldTimeInMonths: holdTimeInMonthsInt,
+		FileName:         c.PostForm("file_name"),
 	}
 	// send message to rabbitmq
 	if err = api.queues.cluster.PublishMessage(qp); err != nil {

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -139,6 +139,7 @@ func (api *API) addFile(c *gin.Context) {
 		Fail(c, err)
 		return
 	}
+	fileName := fileHandler.Filename
 	// validate the size of upload is within limits
 	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
 		Fail(c, err)
@@ -249,7 +250,7 @@ func (api *API) addFile(c *gin.Context) {
 		NetworkName:      "public",
 		UserName:         username,
 		HoldTimeInMonths: holdTimeInMonthsInt,
-		FileName:         c.PostForm("file_name"),
+		FileName:         fileName,
 	}
 	// send message to rabbitmq
 	if err = api.queues.cluster.PublishMessage(qp); err != nil {
@@ -310,6 +311,7 @@ func (api *API) uploadDirectory(c *gin.Context) {
 		Fail(c, err)
 		return
 	}
+	fileName := fileHandler.Filename
 	if err := api.clam.Scan(fh); err != nil {
 		api.LogError(c, err, err.Error())(http.StatusInternalServerError)
 		return
@@ -414,6 +416,7 @@ func (api *API) uploadDirectory(c *gin.Context) {
 		NetworkName:      "public",
 		UserName:         username,
 		HoldTimeInMonths: holdTimeInt,
+		FileName:         fileName,
 	}
 	if err := api.queues.cluster.PublishMessage(qp); err != nil {
 		api.LogError(c, err, eh.QueuePublishError)(http.StatusInternalServerError)

--- a/api/v2/routes_rtfsp_usage.go
+++ b/api/v2/routes_rtfsp_usage.go
@@ -69,6 +69,7 @@ func (api *API) pinToHostedIPFSNetwork(c *gin.Context) {
 		HoldTimeInMonths: holdTimeInt,
 		CreditCost:       0,
 		JWT:              GetAuthToken(c),
+		FileName:         c.PostForm("file_name"),
 	}
 	// send message for processing
 	if err = api.queues.pin.PublishMessage(ip); err != nil {
@@ -192,6 +193,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 			NetworkName:      forms["network_name"],
 			Username:         username,
 			HoldTimeInMonths: holdTimeInt,
+			FileName:         c.PostForm("file_name"),
 		})
 	} else {
 		_, err = api.upm.UpdateUpload(holdTimeInt, username, resp, forms["network_name"])

--- a/api/v2/routes_rtfsp_usage.go
+++ b/api/v2/routes_rtfsp_usage.go
@@ -117,6 +117,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 		Fail(c, err)
 		return
 	}
+	fileName := fileHandler.Filename
 	// validate file size
 	if err := api.FileSizeCheck(fileHandler.Size); err != nil {
 		Fail(c, err)
@@ -193,7 +194,7 @@ func (api *API) addFileToHostedIPFSNetwork(c *gin.Context) {
 			NetworkName:      forms["network_name"],
 			Username:         username,
 			HoldTimeInMonths: holdTimeInt,
-			FileName:         c.PostForm("file_name"),
+			FileName:         fileName,
 		})
 	} else {
 		_, err = api.upm.UpdateUpload(holdTimeInt, username, resp, forms["network_name"])

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RTradeLtd/cmd/v2 v2.1.0
 	github.com/RTradeLtd/config/v2 v2.1.5
 	github.com/RTradeLtd/crypto/v2 v2.1.1
-	github.com/RTradeLtd/database/v2 v2.6.0
+	github.com/RTradeLtd/database/v2 v2.6.1
 	github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636
 	github.com/RTradeLtd/go-ipfs-api v0.0.0-20190522213636-8e3700e602fd
 	github.com/RTradeLtd/grpc v0.0.0-20190528193535-5184ecc77228

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RTradeLtd/cmd/v2 v2.1.0
 	github.com/RTradeLtd/config/v2 v2.1.5
 	github.com/RTradeLtd/crypto/v2 v2.1.1
-	github.com/RTradeLtd/database/v2 v2.5.0
+	github.com/RTradeLtd/database/v2 v2.6.0-rc1
 	github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636
 	github.com/RTradeLtd/go-ipfs-api v0.0.0-20190522213636-8e3700e602fd
 	github.com/RTradeLtd/grpc v0.0.0-20190528193535-5184ecc77228

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RTradeLtd/cmd/v2 v2.1.0
 	github.com/RTradeLtd/config/v2 v2.1.5
 	github.com/RTradeLtd/crypto/v2 v2.1.1
-	github.com/RTradeLtd/database/v2 v2.6.0-rc1
+	github.com/RTradeLtd/database/v2 v2.6.0
 	github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636
 	github.com/RTradeLtd/go-ipfs-api v0.0.0-20190522213636-8e3700e602fd
 	github.com/RTradeLtd/grpc v0.0.0-20190528193535-5184ecc77228

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/RTradeLtd/crypto/v2 v2.1.1 h1:P59zYkkNkl6K1KiTRvW52AYwLvwmtzuzZ9+AjLW
 github.com/RTradeLtd/crypto/v2 v2.1.1/go.mod h1:saIQ67Btn4JWsOdzjn9U6Dl+aZlg+YKgg4RsQKXxjf4=
 github.com/RTradeLtd/database/v2 v2.5.0 h1:XpMfvBFT4L9wACXS1AMrmKHDbyFkA7m6QqP+UB9FCwk=
 github.com/RTradeLtd/database/v2 v2.5.0/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
+github.com/RTradeLtd/database/v2 v2.6.0-rc1 h1:eQZl9HCyyaRz4QBB8VzZs5vCoh+m7/Bny4DI33Ce60Y=
+github.com/RTradeLtd/database/v2 v2.6.0-rc1/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636 h1:i/+1LBA+YMfD1m9UnQP52A7S6y2U3C0xpMBehPkDRug=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636/go.mod h1:zpzHNRdCMCG9PM9QO5jVSldXCRMJ7lY42yJ5TEe//7M=
 github.com/RTradeLtd/go-ipfs-api v0.0.0-20190308091756-8b7099fd5e21 h1:AHtzjhhX63ayVKzYZbNv+LL7sHieM6IKRSa08QQSz60=

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,8 @@ github.com/RTradeLtd/crypto v2.0.0+incompatible h1:3+UEo0upD0p3A+7yLJ14UJpT6aZEh
 github.com/RTradeLtd/crypto v2.0.0+incompatible/go.mod h1:xhKwg748pxs2as6Ts65TiBBFrYzntioTqBIZEa1BUio=
 github.com/RTradeLtd/crypto/v2 v2.1.1 h1:P59zYkkNkl6K1KiTRvW52AYwLvwmtzuzZ9+AjLWmKsU=
 github.com/RTradeLtd/crypto/v2 v2.1.1/go.mod h1:saIQ67Btn4JWsOdzjn9U6Dl+aZlg+YKgg4RsQKXxjf4=
-github.com/RTradeLtd/database/v2 v2.5.0 h1:XpMfvBFT4L9wACXS1AMrmKHDbyFkA7m6QqP+UB9FCwk=
-github.com/RTradeLtd/database/v2 v2.5.0/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
-github.com/RTradeLtd/database/v2 v2.6.0-rc1 h1:eQZl9HCyyaRz4QBB8VzZs5vCoh+m7/Bny4DI33Ce60Y=
-github.com/RTradeLtd/database/v2 v2.6.0-rc1/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
+github.com/RTradeLtd/database/v2 v2.6.0 h1:NhVxzQaC3LxExql0Np0gLxFD6lEs0bovz0mfP+dH1Cc=
+github.com/RTradeLtd/database/v2 v2.6.0/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636 h1:i/+1LBA+YMfD1m9UnQP52A7S6y2U3C0xpMBehPkDRug=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636/go.mod h1:zpzHNRdCMCG9PM9QO5jVSldXCRMJ7lY42yJ5TEe//7M=
 github.com/RTradeLtd/go-ipfs-api v0.0.0-20190308091756-8b7099fd5e21 h1:AHtzjhhX63ayVKzYZbNv+LL7sHieM6IKRSa08QQSz60=

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/RTradeLtd/crypto v2.0.0+incompatible h1:3+UEo0upD0p3A+7yLJ14UJpT6aZEh
 github.com/RTradeLtd/crypto v2.0.0+incompatible/go.mod h1:xhKwg748pxs2as6Ts65TiBBFrYzntioTqBIZEa1BUio=
 github.com/RTradeLtd/crypto/v2 v2.1.1 h1:P59zYkkNkl6K1KiTRvW52AYwLvwmtzuzZ9+AjLWmKsU=
 github.com/RTradeLtd/crypto/v2 v2.1.1/go.mod h1:saIQ67Btn4JWsOdzjn9U6Dl+aZlg+YKgg4RsQKXxjf4=
-github.com/RTradeLtd/database/v2 v2.6.0 h1:NhVxzQaC3LxExql0Np0gLxFD6lEs0bovz0mfP+dH1Cc=
-github.com/RTradeLtd/database/v2 v2.6.0/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
+github.com/RTradeLtd/database/v2 v2.6.1 h1:q3DHd/DFIrGX1sw4IzXi1Rz0kMcEDogUG405rHkV0W8=
+github.com/RTradeLtd/database/v2 v2.6.1/go.mod h1:7t4vOzLgmvIz9qnZC0UY0cwdbpkVIhE6I9BaCKV4/us=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636 h1:i/+1LBA+YMfD1m9UnQP52A7S6y2U3C0xpMBehPkDRug=
 github.com/RTradeLtd/entropy-mnemonics v0.0.0-20170316012907-7b01a644a636/go.mod h1:zpzHNRdCMCG9PM9QO5jVSldXCRMJ7lY42yJ5TEe//7M=
 github.com/RTradeLtd/go-ipfs-api v0.0.0-20190308091756-8b7099fd5e21 h1:AHtzjhhX63ayVKzYZbNv+LL7sHieM6IKRSa08QQSz60=

--- a/queue/ipfs.go
+++ b/queue/ipfs.go
@@ -182,7 +182,8 @@ func (qm *Manager) processIPFSPin(d amqp.Delivery, wg *sync.WaitGroup, usrm *mod
 		_, err = upldm.NewUpload(pin.CID, "pin", models.UploadOptions{
 			NetworkName:      pin.NetworkName,
 			Username:         pin.UserName,
-			HoldTimeInMonths: pin.HoldTimeInMonths})
+			HoldTimeInMonths: pin.HoldTimeInMonths,
+			FileName:         pin.FileName})
 	} else {
 		// the record already exists so we will update
 		_, err = upldm.UpdateUpload(pin.HoldTimeInMonths, pin.UserName, pin.CID, pin.NetworkName)

--- a/queue/ipfs_cluster.go
+++ b/queue/ipfs_cluster.go
@@ -101,7 +101,8 @@ func (qm *Manager) processIPFSClusterPin(ctx context.Context, d amqp.Delivery, w
 		_, err = um.NewUpload(clusterAdd.CID, "pin-cluster", models.UploadOptions{
 			NetworkName:      clusterAdd.NetworkName,
 			Username:         clusterAdd.UserName,
-			HoldTimeInMonths: clusterAdd.HoldTimeInMonths})
+			HoldTimeInMonths: clusterAdd.HoldTimeInMonths,
+			FileName:         clusterAdd.FileName})
 	} else {
 		_, err = um.UpdateUpload(clusterAdd.HoldTimeInMonths, clusterAdd.UserName, clusterAdd.CID, clusterAdd.NetworkName)
 	}

--- a/queue/types.go
+++ b/queue/types.go
@@ -101,6 +101,7 @@ type IPFSPin struct {
 	CreditCost       float64 `json:"credit_cost"`
 	Size             int64   `json:"size"`
 	JWT              string  `json:"jwt,omitempty"`
+	FileName         string  `json:"file_name,omitempty"`
 }
 
 // IPFSClusterPin is a queue message used when sending a message to the cluster to pin content
@@ -111,6 +112,7 @@ type IPFSClusterPin struct {
 	HoldTimeInMonths int64   `json:"hold_time_in_months"`
 	Size             int64   `json:"size"`
 	CreditCost       float64 `json:"credit_cost"`
+	FileName         string  `json:"file_name,omitempty"`
 }
 
 // IPNSUpdate is our message for the ipns update queue


### PR DESCRIPTION
## :construction_worker: Purpose
Revamping the playground which means we will no longer be using mongodb to store filename information, as this will now be captured by postgres.


## :rocket: Changes

* Record filename when upload files and pinning files. Enable providing optional name to pins.
* Pin API calls now take an optional `file_name` post form parameter that lets you name the pin. If you do not specify one, the file name is an empty string
* File upload API calls derive the filename from the upload itself and is not overridable.


## :warning: Breaking Changes

None

