### PR TITLE
Cache CMC Price Lookups

### DIFF
--- a/api/v2/routes_payment.go
+++ b/api/v2/routes_payment.go
@@ -509,21 +509,33 @@ func (api *API) getPaymentStatus(c *gin.Context) {
 
 // GetUSDValue is used to retrieve the usd value of a given payment type
 func (api *API) getUSDValue(paymentType string) (float64, error) {
+	var (
+		cost float64
+		err  error
+	)
 	switch paymentType {
 	case "eth":
-		return utils.RetrieveUsdPrice("ethereum")
+		cost, err = utils.RetrieveUsdPrice("ethereum")
 	case "xmr":
-		return utils.RetrieveUsdPrice("monero")
+		cost, err = utils.RetrieveUsdPrice("monero")
 	case "dash":
-		return utils.RetrieveUsdPrice("dash")
+		cost, err = utils.RetrieveUsdPrice("dash")
 	case "btc":
-		return utils.RetrieveUsdPrice("bitcoin")
+		cost, err = utils.RetrieveUsdPrice("bitcoin")
 	case "bch":
-		return utils.RetrieveUsdPrice("bitcoin-cash")
+		cost, err = utils.RetrieveUsdPrice("bitcoin-cash")
 	case "ltc":
-		return utils.RetrieveUsdPrice("litecoin")
+		cost, err = utils.RetrieveUsdPrice("litecoin")
 	case "rtc":
-		return RtcCostUsd, nil
+		cost, err = RtcCostUsd, nil
+	default:
+		return 0, errors.New(eh.InvalidPaymentTypeError)
 	}
-	return 0, errors.New(eh.InvalidPaymentTypeError)
+	// if we have an error, and the cost is 0 return the error
+	// otherwise if we have an error, and a non-zero cost
+	// then we should return the most recent price we have
+	if err != nil && cost == 0 {
+		return 0, err
+	}
+	return cost, nil
 }

--- a/utils/cmc.go
+++ b/utils/cmc.go
@@ -50,7 +50,12 @@ func init() {
 	}
 }
 
-// RetrieveUsdPrice is used to retrieve the USD price for a coin from CMC
+// RetrieveUsdPrice is used to retrieve the USD price for a coin from CMC.
+//
+// Whenever we have a "fresh" coin price that is newer than 10 minutes
+// we will return that price instead of querying coinmarketcap. In the event
+// of a "stale" value we will hit the coinmarketcap api. If that errors
+// then we return both the error, and whatever price we have in-memory
 func RetrieveUsdPrice(coin string) (float64, error) {
 	pricer.mux.RLock()
 	if pricer.coins[coin].price != 0 {

--- a/utils/cmc.go
+++ b/utils/cmc.go
@@ -20,7 +20,7 @@ type coinPrice struct {
 	nextRefresh time.Time
 }
 type priceChecker struct {
-	coins map[string]*coinPrice
+	coins map[string]coinPrice
 	mux   *sync.RWMutex
 }
 
@@ -45,7 +45,7 @@ type Response struct {
 
 func init() {
 	pricer = &priceChecker{
-		coins: make(map[string]*coinPrice),
+		coins: make(map[string]coinPrice),
 		mux:   &sync.RWMutex{},
 	}
 }
@@ -83,7 +83,9 @@ REFRESH:
 	if err != nil {
 		return 0, err
 	}
-	pricer.coins[coin].price = cost
-	pricer.coins[coin].nextRefresh = time.Now().Add(time.Minute * 10)
+	pricer.coins[coin] = coinPrice{
+		price:       cost,
+		nextRefresh: time.Now().Add(time.Minute * 10),
+	}
 	return cost, nil
 }

--- a/utils/cmc.go
+++ b/utils/cmc.go
@@ -71,20 +71,20 @@ REFRESH:
 	url := fmt.Sprintf("%s/%s", tickerURL, coin)
 	response, err := http.Get(url)
 	if err != nil {
-		return 0, err
+		return pricer.coins[coin].price, err
 	}
 
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return 0, err
+		return pricer.coins[coin].price, err
 	}
 	var decode []Response
 	if err = json.Unmarshal(body, &decode); err != nil {
-		return 0, err
+		return pricer.coins[coin].price, err
 	}
 	cost, err := strconv.ParseFloat(decode[0].PriceUsd, 64)
 	if err != nil {
-		return 0, err
+		return pricer.coins[coin].price, err
 	}
 	pricer.coins[coin] = coinPrice{
 		price:       cost,

--- a/utils/cmc.go
+++ b/utils/cmc.go
@@ -65,6 +65,9 @@ REFRESH:
 	pricer.mux.RUnlock()
 	pricer.mux.Lock()
 	defer pricer.mux.Unlock()
+	if pricer.coins[coin].price != 0 && !time.Now().After(pricer.coins[coin].nextRefresh) {
+		return pricer.coins[coin].price, nil
+	}
 	url := fmt.Sprintf("%s/%s", tickerURL, coin)
 	response, err := http.Get(url)
 	if err != nil {

--- a/utils/cmc_test.go
+++ b/utils/cmc_test.go
@@ -31,6 +31,13 @@ func TestRetrieveUsdPrice(t *testing.T) {
 			if price == 0 && tt.args.coin != "NotARealCoin" {
 				t.Error("price is 0, unexpected result")
 			}
+			price, err = utils.RetrieveUsdPrice(tt.args.coin)
+			if (err != nil) != tt.wantErr {
+				t.Error(err)
+			}
+			if price == 0 && tt.args.coin != "NotARealCoin" {
+				t.Error("price is 0, unexpected result")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## :construction_worker: Purpose

Closes https://github.com/RTradeLtd/Temporal/issues/400 and enables an in-memory cache of cmc prices to prevent excessive requests.

## :rocket: Changes

* Cache successful cmc price lookups in-memory
* When a cmc price lookup fails, return the in-memory price and error
* Within the API, ignore errors when retrieving usd prices *if* the returned price is non-zero

## :warning: Breaking Changes

None
