### PR TITLE
api/v2: Add hostname to systems check HTTP response headers #421

### DIFF
--- a/api/v2/routes_utils.go
+++ b/api/v2/routes_utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/RTradeLtd/Temporal/eh"
@@ -19,6 +20,12 @@ import (
 
 // SystemsCheck is a basic check of system integrity
 func (api *API) SystemsCheck(c *gin.Context) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		api.LogError(c, err, eh.HostNameNotFoundError)(http.StatusInternalServerError)
+		return
+	}
+	c.Writer.Header().Set("X-API-Hostname", hostname)
 	Respond(c, http.StatusOK, gin.H{
 		"version":  api.version,
 		"response": "systems online",

--- a/eh/errors.go
+++ b/eh/errors.go
@@ -132,4 +132,6 @@ const (
 	PinExtendError = "failed to extend pin duration, this likely means you haven't actually uploaded this content before"
 	// MaxHoldTimeError is an error message when the current hold time value would breach set pin time limits
 	MaxHoldTimeError = "a hold time of this long would result in a longer maximum pin time of 2 years, please reduce your hold time and try again"
+	// HostNameNotFoundError is an error message when api server has not hostname
+	HostNameNotFoundError = "an api host has not hostname, please set hostname"
 )


### PR DESCRIPTION
## :construction_worker: Purpose

Fixes: #421 

## :rocket: Changes

To add response header (`X-API-Host: hostname`)to request router `/v2/systems/check`

## :warning: Breaking Changes
If the API server does not  set a hostname, response cannot help returning 5XX status code.

