### PR TITLE
Enable Paginated Responses For Large Payload Calls

### DIFF
--- a/api/v2/api_test.go
+++ b/api/v2/api_test.go
@@ -77,7 +77,8 @@ type stringSliceAPIResponse struct {
 	Response []string `json:"response"`
 }
 
-// sendRequest is a helper method used to handle sending an api request
+// sendRequestPaged is a helper method used to handle sending an api request with paged responses
+// If `out` is not nil, the response from the API will be unmarshaled into `out`.
 func sendRequestPaged(
 	api *API,
 	method, url string,
@@ -115,6 +116,7 @@ func sendRequestPaged(
 }
 
 // sendRequest is a helper method used to handle sending an api request
+// If `out` is not nil, the response from the API will be unmarshaled into `out`.
 func sendRequest(api *API, method, url string, wantStatus int, body io.Reader, urlValues url.Values, out interface{}) error {
 	testRecorder := httptest.NewRecorder()
 	req := httptest.NewRequest(method, url, body)

--- a/api/v2/routes_database.go
+++ b/api/v2/routes_database.go
@@ -16,7 +16,7 @@ func (api *API) getUploadsForUser(c *gin.Context) {
 		return
 	}
 	if c.Query("paged") == "true" {
-		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), []models.Upload{})
+		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), &[]models.Upload{})
 		return
 	}
 	// fetch all uploads by the specified user
@@ -48,7 +48,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 		api.pageIt(c, api.upm.DB.Where(
 			"user_name = ? AND network_name = ?",
 			username, networkName,
-		), []models.Upload{})
+		), &[]models.Upload{})
 		return
 	}
 	// find uploads for the network

--- a/api/v2/routes_database.go
+++ b/api/v2/routes_database.go
@@ -15,7 +15,7 @@ func (api *API) getUploadsForUser(c *gin.Context) {
 		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
-	if c.Param("paged") == "true" {
+	if c.Query("paged") == "true" {
 		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), []models.Upload{})
 		return
 	}
@@ -44,7 +44,7 @@ func (api *API) getUploadsByNetworkName(c *gin.Context) {
 		api.LogError(c, err, eh.PrivateNetworkAccessError)(http.StatusBadRequest)
 		return
 	}
-	if c.Param("paged") == "true" {
+	if c.Query("paged") == "true" {
 		api.pageIt(c, api.upm.DB.Where(
 			"user_name = ? AND network_name = ?",
 			username, networkName,

--- a/api/v2/routes_database_test.go
+++ b/api/v2/routes_database_test.go
@@ -37,15 +37,23 @@ func Test_API_Routes_Database(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	// validate the response code
-	if interfaceAPIResp.Code != 200 {
-		t.Fatal("bad api status code from api/v2/database/uploads")
+	// test paginated
+	interfaceAPIResp = interfaceAPIResponse{}
+	if err := sendRequest(
+		api, "GET", "/v2/database/uploads?paged=true", 200, nil, nil, &interfaceAPIResp,
+	); err != nil {
+		t.Fatal(err)
 	}
 
 	// test get encrypted uploads
 	// /v2/frontend/uploads/encrypted
 	if err := sendRequest(
 		api, "GET", "/v2/database/uploads/encrypted", 200, nil, nil, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := sendRequest(
+		api, "GET", "/v2/database/uploads/encrypted?paged=true", 200, nil, nil, nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/api/v2/routes_database_test.go
+++ b/api/v2/routes_database_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/RTradeLtd/Temporal/mocks"
@@ -39,8 +40,14 @@ func Test_API_Routes_Database(t *testing.T) {
 	}
 	// test paginated
 	interfaceAPIResp = interfaceAPIResponse{}
-	if err := sendRequest(
-		api, "GET", "/v2/database/uploads?paged=true", 200, nil, nil, &interfaceAPIResp,
+	if err := sendRequestPaged(
+		api,
+		"GET",
+		"/v2/database/uploads",
+		200,
+		nil,
+		url.Values{"paged": {"true"}},
+		&interfaceAPIResp,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -52,8 +59,15 @@ func Test_API_Routes_Database(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	if err := sendRequest(
-		api, "GET", "/v2/database/uploads/encrypted?paged=true", 200, nil, nil, nil,
+	interfaceAPIResp = interfaceAPIResponse{}
+	if err := sendRequestPaged(
+		api,
+		"GET",
+		"/v2/database/uploads/encrypted",
+		200,
+		nil,
+		url.Values{"paged": {"true"}},
+		&interfaceAPIResp,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/api/v2/routes_frontend.go
+++ b/api/v2/routes_frontend.go
@@ -94,7 +94,7 @@ func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
-	if c.Param("paged") == "true" {
+	if c.Query("paged") == "true" {
 		api.pageIt(c, api.ue.DB.Where("user_name = ?", username), []models.EncryptedUpload{})
 		return
 	}

--- a/api/v2/routes_frontend.go
+++ b/api/v2/routes_frontend.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RTradeLtd/Temporal/eh"
 	"github.com/RTradeLtd/Temporal/utils"
+	"github.com/RTradeLtd/database/v2/models"
 	"github.com/gin-gonic/gin"
 	gocid "github.com/ipfs/go-cid"
 )
@@ -91,6 +92,10 @@ func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
 		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
+		return
+	}
+	if c.Param("paged") == "true" {
+		api.pageIt(c, api.ue.DB.Where("user_name = ?", username), []models.EncryptedUpload{})
 		return
 	}
 	// find all uploads by this user

--- a/api/v2/routes_frontend.go
+++ b/api/v2/routes_frontend.go
@@ -95,7 +95,7 @@ func (api *API) getEncryptedUploadsForUser(c *gin.Context) {
 		return
 	}
 	if c.Query("paged") == "true" {
-		api.pageIt(c, api.ue.DB.Where("user_name = ?", username), []models.EncryptedUpload{})
+		api.pageIt(c, api.ue.DB.Where("user_name = ?", username), &[]models.EncryptedUpload{})
 		return
 	}
 	// find all uploads by this user

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -13,6 +13,7 @@ import (
 	"github.com/RTradeLtd/Temporal/eh"
 	"github.com/RTradeLtd/Temporal/queue"
 	"github.com/RTradeLtd/Temporal/utils"
+	"github.com/RTradeLtd/database/v2/models"
 	gocid "github.com/ipfs/go-cid"
 )
 
@@ -94,6 +95,10 @@ func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 	username, err := GetAuthenticatedUserFromContext(c)
 	if err != nil {
 		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
+		return
+	}
+	if c.Param("paged") == "true" {
+		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), []models.IPNS{})
 		return
 	}
 	// search for all records published by this user

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -97,7 +97,7 @@ func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
 		return
 	}
-	if c.Param("paged") == "true" {
+	if c.Query("paged") == "true" {
 		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), []models.IPNS{})
 		return
 	}

--- a/api/v2/routes_ipns.go
+++ b/api/v2/routes_ipns.go
@@ -98,7 +98,7 @@ func (api *API) getIPNSRecordsPublishedByUser(c *gin.Context) {
 		return
 	}
 	if c.Query("paged") == "true" {
-		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), []models.IPNS{})
+		api.pageIt(c, api.upm.DB.Where("user_name = ?", username), &[]models.IPNS{})
 		return
 	}
 	// search for all records published by this user

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -133,8 +133,14 @@ func Test_API_Routes_IPNS_GET(t *testing.T) {
 			t.Fatal(err)
 		}
 		intAPIResp = interfaceAPIResponse{}
-		if err := sendRequest(
-			api, "GET", "/v2/ipns/records?paged=true", tt.wantStatus, nil, nil, &intAPIResp,
+		if err := sendRequestPaged(
+			api,
+			"GET",
+			"/v2/ipns/records",
+			200,
+			nil,
+			url.Values{"paged": {"true"}},
+			&intAPIResp,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/api/v2/routes_ipns_test.go
+++ b/api/v2/routes_ipns_test.go
@@ -132,6 +132,12 @@ func Test_API_Routes_IPNS_GET(t *testing.T) {
 		); err != nil {
 			t.Fatal(err)
 		}
+		intAPIResp = interfaceAPIResponse{}
+		if err := sendRequest(
+			api, "GET", "/v2/ipns/records?paged=true", tt.wantStatus, nil, nil, &intAPIResp,
+		); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 func Test_API_Routes_IPNS_Pin(t *testing.T) {

--- a/api/v2/utils.go
+++ b/api/v2/utils.go
@@ -47,10 +47,10 @@ func (api *API) pageIt(c *gin.Context, db *gorm.DB, model interface{}) {
 			Page:  pageInt,
 			Limit: limitInt,
 		},
-		&model,
+		model,
 	)
 	if err != nil {
-		api.LogError(c, err, "failed to get paged user upload")
+		api.LogError(c, err, "failed to get paged user upload "+err.Error())(http.StatusBadRequest)
 		return
 	}
 	Respond(c, http.StatusOK, gin.H{"response": paged})

--- a/api/v2/utils.go
+++ b/api/v2/utils.go
@@ -23,11 +23,11 @@ const (
 
 // pageIt is used to serve paginated responses
 func (api *API) pageIt(c *gin.Context, db *gorm.DB, model interface{}) {
-	page := c.Param("page")
+	page := c.Query("page")
 	if page == "" {
 		page = "1"
 	}
-	limit := c.Param("limit")
+	limit := c.Query("limit")
 	if limit == "" {
 		limit = "10"
 	}


### PR DESCRIPTION
## :construction_worker: Purpose

Closes https://github.com/RTradeLtd/Temporal/issues/433

## :rocket: Changes

The following calls now optional return paginated responses:
* Uploads
* Uploads by network
* Encrypted uploads
* IPNS Records

You can invoke paginated responses using `?paged=true` url parameter. Additionally there are two "optional" parameters to control the response:
* `page` = page number (default 1)
* `limit` = max number of results (default 10)

## :warning: Breaking Changes

None this is backwards compatible. Note however this is an "experimental" feature, and the api is subject to change until finalized. That means although we probably wont change the `paged`, `page` and `limit` url params, it's possible.

