### PR TITLE
Enable Cluster Monitoring Script To Return Pin Errors

### DIFF
--- a/setup/scripts/ipfs/ipfs_cluster_monitor.sh
+++ b/setup/scripts/ipfs/ipfs_cluster_monitor.sh
@@ -19,6 +19,10 @@ case "$1" in
         COUNT=$(ipfs-cluster-ctl status --local=true | grep -c PIN_ERROR)
         echo "$COUNT"
         ;;
+    pin-errors)
+        # displays all pin in error status
+        ipfs-cluster-ctl status --filter=error,pin_error,cluster_error
+        ;;
     daemon-status)
         # if this is not 0 then there's an error
         # this is used to avoid scenarios where the cluster service is up
@@ -36,7 +40,7 @@ case "$1" in
         ;;
     *)
         echo "invalid invocation"
-        echo "valid commands: peer-count, queued-pin-count, pin-count, error-count, daemon-status"
+        echo "valid commands: peer-count, queued-pin-count, pin-count, error-count, daemon-status, pin-errors"
         exit 1
         ;;
 


### PR DESCRIPTION
## :construction_worker: Purpose

Tired of typing this command out, or using CTRL+R, plus this can be used with zabbix or grafana for more fine grained monitoring


## :rocket: Changes

Add a command to the cluster monitoring script that returns all pins in all error states

## :warning: Breaking Changes

None

