### PR TITLE
Fix Paged Results

### DIFF
--- a/api/v2/utils.go
+++ b/api/v2/utils.go
@@ -47,6 +47,8 @@ func (api *API) pageIt(c *gin.Context, db *gorm.DB, model interface{}) {
 			DB:    db,
 			Page:  pageInt,
 			Limit: limitInt,
+			// sort results starting with newest first
+			OrderBy: []string{"created_at DESC"},
 		},
 		model,
 	)


### PR DESCRIPTION
## :construction_worker: Purpose

Paged results were returning responses in not always the same order.

## :rocket: Changes

Sort paged results by creation at date



## :warning: Breaking Changes

None
