### PR TITLE
Enable TemporalX License Purchase From API (WIP)

### DIFF
--- a/api/v2/routes_payment.go
+++ b/api/v2/routes_payment.go
@@ -450,7 +450,7 @@ func (api *API) stripeChargeTemporalX(c *gin.Context) {
 	}
 	// initialize credit card charge parameters
 	ch, err := charge.New(&stripe.ChargeParams{
-		Amount:      stripe.Int64(299),
+		Amount:      stripe.Int64(335), // equivalent to purchase cose + GST&PST provincial taxes
 		Currency:    stripe.String(string(stripe.CurrencyUSD)),
 		Description: stripe.String("temporalx 3-node license purchase"),
 		// StatementDescriptor is what appears in their credit card billing report


### PR DESCRIPTION
## :construction_worker: Purpose

Instead of having to manually process payments and license purchases, enable automated payment acceptance.

## :rocket: Changes

Adds API call to charge users for TemporalX 3 node license purchase & factor in GST+PST

## :warning: Breaking Changes


None