### PR TITLE
Enable Pin Removal Via API

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -543,6 +543,7 @@ func (api *API) setupRoutes(debug bool) error {
 			{
 				pin.POST("/:hash", api.pinHashLocally)
 				pin.POST("/:hash/extend", api.extendPin)
+				pin.DELETE("/remove/:hash", api.removePin)
 			}
 			// file upload routes
 			file := public.Group("/file")
@@ -586,7 +587,6 @@ func (api *API) setupRoutes(debug bool) error {
 			{
 				pin.POST("/:hash", api.pinToHostedIPFSNetwork)
 				pin.GET("/check/:hash/:networkName", api.checkLocalNodeForPinForHostedIPFSNetwork)
-				pin.DELETE("/remove/:hash", api.removePin)
 			}
 			// file upload routes
 			file := private.Group("/file")

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -586,6 +586,7 @@ func (api *API) setupRoutes(debug bool) error {
 			{
 				pin.POST("/:hash", api.pinToHostedIPFSNetwork)
 				pin.GET("/check/:hash/:networkName", api.checkLocalNodeForPinForHostedIPFSNetwork)
+				pin.DELETE("/remove/:hash", api.removePin)
 			}
 			// file upload routes
 			file := private.Group("/file")

--- a/api/v2/routes_rtfs.go
+++ b/api/v2/routes_rtfs.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"html"
 	"io"
 	"io/ioutil"
@@ -393,4 +394,23 @@ func (api *API) extendPin(c *gin.Context) {
 	}
 	// return
 	Respond(c, http.StatusOK, gin.H{"response": "pin time successfully extended"})
+}
+
+func (api *API) removePin(c *gin.Context) {
+	username, err := GetAuthenticatedUserFromContext(c)
+	if err != nil {
+		api.LogError(c, err, eh.NoAPITokenError)(http.StatusBadRequest)
+		return
+	}
+	// validate hash
+	hash := c.Param("hash")
+	if _, err := gocid.Decode(hash); err != nil {
+		Fail(c, err)
+		return
+	}
+	if err := api.upm.RemovePin(username, hash, "public"); err != nil {
+		api.LogError(c, err, fmt.Sprint(eh.PinRemovalError+"hash: "+hash))(http.StatusBadRequest)
+		return
+	}
+	Respond(c, http.StatusOK, gin.H{"response": "pin successfuly removed with partial cost refunded"})
 }

--- a/eh/errors.go
+++ b/eh/errors.go
@@ -134,4 +134,6 @@ const (
 	MaxHoldTimeError = "a hold time of this long would result in a longer maximum pin time than what your account allow, please reduce your hold time and try again"
 	// HostNameNotFoundError is an error message when api server has not hostname
 	HostNameNotFoundError = "an api host has not hostname, please set hostname"
+	// PinRemovalError is an error message when we failed to remove a pin
+	PinRemovalError = "failed to remove pin and refund partial cost"
 )


### PR DESCRIPTION
# :warning: 

This introduces a credits exploit to get 3GB * 12 months of free credits, and will be postponed until this can be mitigated:

* Create free account
* Upload 3GB of data pinned for 12 months
* Upgrade account to paid tier immediately
* Remove the 3GB of pins
* You will be refunded approximately `~11.75months * 3GB` worth of credits

Possible ideas:


* 1)
  *When upgrading, have a database column in user account that indicates the time they upgraded at
  * Prevent refunding any uploads whose `created_at` is before the upgrade time, but allow them to be removed
  * Downside with this is the upgraded_at field would be introduced in this PR, and as such any uploads from before then wouldn't be eligible for refunds
* 2)
  * Dont allow any refunds (tbh while this is the "easiest" it is definitely the shittiest to our users)
  * Only do this if there is no other possible option

   


## :construction_worker: Purpose

This functionality has been enabled in the database manager we use, but hasn't been exposed via the API.  

**Note that free tier account users are unable to remove pins, and must wait for their pins to expire. This is done because repeated pinning and pin removal can be used as a vector for DoS'ing IPFS nodes by enabling pinning massive amounts of pins.**

**The reason this is a DoS vector is because the more pins your IPFS nodes have, the slower they become when adding new data. Additionally it means that when garbage collect is run, it takes a lot more time. To give an idea on how long, due the amount of data our IPFS nodes have, running garbage collection takes days to complete, which is a blocking process requiring the node be inaccessible.**

**Additionally we only do a partial refund on the remaining storage costs, minus a 72 hour buffer to accomodate for the garbage collection process, and to also prevent paid accounts from using the same DoS vector. If there was a complete refund paid accounts could pin+unpin immediately being able to exploit the DoS vector.**

**While this may be upsetting to some, it is a necessary step. The go-ipfs garbage collection system is unbelievably slow, and sometimes does not work requiring a complete wipe of the data directory, and copying over the data again. It is unfortunate, but to keep our service fast for all users, it is a necessary measure.**

## :rocket: Changes

* Enable pin removal and include a partial refund cost

## :warning: Breaking Changes


None


## TODOs

* Enable pin removal for encrypted uploads
  * To do this if the pin removal call fails with an upload not found error attempt to delete via the encrypted upload models, if that fails return an error
* Add tests